### PR TITLE
Enlarge scope of intro text and title

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,9 +1,9 @@
 +++
-title = "Tutorials on freeware open source software"
+title = "Tutorials Research Institute for Nature and Forest (INBO)"
 description = ""
 date = "2017-04-24T18:36:24+02:00"
 +++
 
-# Tutorials on freeware open source software
+# Tutorials Research Institute for Nature and Forest (INBO)
 
-Here you can find the source files for the instructions on the use, installation, and development of freeware open source research software at the [Research Institute of Nature and Forest (INBO)](https://www.inbo.be).
+Here you can find the source files for the instructions on the use, installation, and development of research software at the [Research Institute of Nature and Forest (INBO)](https://www.inbo.be).


### PR DESCRIPTION
I would opt to not focus on the `freeware open source`, as this intended as a general overview and hub towards all kind of tutorials. 