### PR TITLE
Update CRS table

### DIFF
--- a/content/spatial/transform.Rmd
+++ b/content/spatial/transform.Rmd
@@ -31,7 +31,7 @@ proj4string(ngi) <- CRS("+init=epsg:3812")
 proj4string(ngi)
 ```
 
-We could verify the correctness of this position by plotting in on a map. Here we use the `leaflet` package which requires the data to be in the "WGSS84" coordinates system. Therefore we use `spTransform` to do this transformation. "WGS84" has EPSG number 4326. But here the projection string itself is easier to memorise: "+proj=longlat".
+We could verify the correctness of this position by plotting in on a map. Here we use the `leaflet` package which requires the data to be in the "WGS84" coordinates system. Therefore we use `spTransform` to do this transformation. "WGS84" has EPSG number 4326. But here the projection string itself is easier to memorise: "+proj=longlat".
 
 ```{r}
 ngi_ll <- spTransform(ngi, CRS("+proj=longlat"))

--- a/content/spatial/transform.Rmd
+++ b/content/spatial/transform.Rmd
@@ -44,11 +44,11 @@ leaflet(ngi_ll) %>%
 ```{r echo = FALSE}
 kable(
   data.frame(
-    Projection = c("WGS84", "Lambert 72", "Lambert 2008", "web Mercator"),
+    CRS = c("WGS 84", "Belge 1972 / Belgian Lambert 72", "ETRS89 / Belgian Lambert 2008", "WGS 84 / Pseudo-Mercator"),
     EPSG = c(4326, 31370, 3812, 3857),
-    CRS = c("+proj=longlat", "+init=epsg:31370", "+init=epsg:3812", "+init=epsg:3857")
+    shortened_PROJ.4_string = c("+init=epsg:4326", "+init=epsg:31370", "+init=epsg:3812", "+init=epsg:3857")
   ),
-  caption = "Relevant projections for Belgian data"
+  caption = "Relevant projections for Belgian data. CRS = Coordinate reference system, EPSG = CRS number in the EPSG dataset."
 )
 ```
 


### PR DESCRIPTION
official CRS names inserted, added explanation in caption, modified PROJ.4 string:

- CRS names have been taken from `/usr/share/proj/epsg`
  - note on Lambert 72: actually two entries exist: _Belge_ vs. _Belgian_ Lambert 72 (31300 / 31370); according to EPSG both give the same results but they advise 31370
- the full PROJ.4 string for WGS 84 is `+proj=longlat +datum=WGS84 +no_defs` (e.g. from `gdalsrsinfo epsg:4326`), even though it may assume the WGS 84 datum from `+proj=longlat` (which, in itself, just says it is a geodetic CRS). Many other CRSes exist that use `+proj=longlat`.