### PR TITLE
use http repositories

### DIFF
--- a/content/installation/admin/Rprofile.site
+++ b/content/installation/admin/Rprofile.site
@@ -9,8 +9,8 @@ options(
   ypinch = 300,
   yaml.eval.expr = TRUE,
   repos = c(
-    RStudio = "https://cloud.r-project.org/",
-    INLA = "https://inla.r-inla-download.org/R/stable"
+    RStudio = "http://cloud.r-project.org/",
+    INLA = "http://inla.r-inla-download.org/R/stable"
   ),
   install.packages.check.source = "no",
   install.packages.compile.from.source = "never"


### PR DESCRIPTION
https yields error when installing packages on windows