### PR TITLE
Use CC-BY license for content + correct name of INBO

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -39,9 +39,9 @@ gopher = "" # used in 404 template ( Generator: https://gopherize.me )
 
 [params.copyright]
 prefix = ""
-holder = "Institute of Nature and Forest research"
+holder = "Research Institute for Nature and Forest (INBO)"
 startYear = "2018"
-suffix = ""
+suffix = "<a href='http://creativecommons.org/licenses/by/4.0/'>Some rights reserved</a>."
 
 [params.settings]
 # date & time format: https://golang.org/pkg/time/

--- a/config.toml
+++ b/config.toml
@@ -41,7 +41,7 @@ gopher = "" # used in 404 template ( Generator: https://gopherize.me )
 prefix = ""
 holder = "Research Institute for Nature and Forest (INBO)"
 startYear = "2018"
-suffix = "<a href='http://creativecommons.org/licenses/by/4.0/'>Some rights reserved</a>."
+suffix = "<a rel='license' href='http://creativecommons.org/licenses/by/4.0/' style='float: right;'><img alt='Creative Commons License' src='https://i.creativecommons.org/l/by/4.0/88x31.png'></a>"
 
 [params.settings]
 # date & time format: https://golang.org/pkg/time/


### PR DESCRIPTION
I think we want our tutorials to be reusable by others? Which is why I added a [CC-BY license](https://creativecommons.org/licenses/by/4.0/) after our copyright statement.

I used

> [Some rights reserved](http://creativecommons.org/licenses/by/4.0/)

Rather than

> This work is licensed under a [Creative Commons Attribution 4.0 International License](http://creativecommons.org/licenses/by/4.0/)

So that it fits on one line

