### PR TITLE
Fix #90: order recent entries by date

### DIFF
--- a/layouts/partials/widgets/recent_posts.html
+++ b/layouts/partials/widgets/recent_posts.html
@@ -1,0 +1,20 @@
+{{- $defaultConfig := .Site.Data.config.default.widgets.recent_posts -}}
+{{- $configData := ( or .Site.Data.config.widgets.recent_posts $defaultConfig ) -}}
+{{- $lang := .Site.Language.Lang -}}
+{{- $config := ( ( index $configData $lang ) | default $configData ) -}}
+
+{{- $length := ( $config.length | default 5 ) -}}
+
+<section class='widget widget-recent_posts sep-after'>
+  <header>
+    <h4 class='title widget-title'>
+      {{- $config.title | default ( i18n "recentPosts" ) -}}
+    </h4>
+  </header>
+
+  <ul class='list'>
+  {{ range first $length ( where .Site.RegularPages "Type" "not in" $config.excludeTypes ).ByDate.Reverse }}
+    {{ .Render "li" }}
+  {{ end }}
+  </ul>
+</section>


### PR DESCRIPTION
Fixed by copying `recent_posts.html` to `layouts/partials/widgets` so it can be customized (standard procedure for anything we want to customize in the theme). Added `ByDate.Reverse` (https://gohugo.io/templates/lists#reverse-order) and removed  `sort` who didn't need to be there.

<img width="568" alt="screenshot 2019-01-28 at 10 07 04" src="https://user-images.githubusercontent.com/600993/51825177-8291ec80-22e4-11e9-997d-c69e00f9f856.png">
