### PR TITLE
Adapt inla workshop

### DIFF
--- a/content/tutorials/r_inla/index.md
+++ b/content/tutorials/r_inla/index.md
@@ -3,9 +3,11 @@ title: "INLA workshops"
 description: "Slides, code and data used during the INLA workshop"
 author: "Thierry Onkelinx"
 date: 2019-03-10
-categories: ["statistics"]
+categories: ["r", "statistics"]
 tags: ["r", "INLA", "inlabru", "analysis", "mixed model"]
 ---
+
+These workshops are a follow-up of the course on "Spatial, temporal and spatial-temporal models using [R-INLA](http://www.r-inla.org/)" by Alain Zuur and Elena Ieno ([Highland Statistics Ltd.](http://www.highstat.com)). The main goal is the get people using R-INLA with their own data in a workshop setting so they can tap into the knowledge of others. The workshops are not a copy of the Highstat course but elaborate certain topics. We also introduce the [`inlatools`](https://inlatools.netlify.com) and [`inlabru`](http://inlabru.org). 
 
 ## Workshop 1
 
@@ -13,4 +15,12 @@ Fitting models with only fixed effects, random intercepts and first order random
 
 - [slides](https://inbo.github.io/tutorials/tutorials/r-inla/random_intercept.pdf)
 - [source code and data](https://github.com/inbo/tutorials/tree/master/content/tutorials/r-inla/random_intercept)
-- [HackMD](https://hackmd.io/mzLJIfJZRySKzrmTXWi0Zg)
+- [HackMD](https://hackmd.io/mzLJIfJZRySKzrmTXWi0Zg), a place to share your code related to this workshop.
+
+## Workshop 2
+
+Work in progress
+
+## Workshop 3
+
+Work in progress

--- a/content/tutorials/r_inla/index.md
+++ b/content/tutorials/r_inla/index.md
@@ -3,7 +3,7 @@ title: "INLA workshops"
 description: "Slides, code and data used during the INLA workshop"
 author: "Thierry Onkelinx"
 date: 2019-03-10
-categories: ["statistical analysis"]
+categories: ["statistics"]
 tags: ["r", "INLA", "inlabru", "analysis", "mixed model"]
 ---
 

--- a/content/tutorials/r_inla/index.md
+++ b/content/tutorials/r_inla/index.md
@@ -2,7 +2,7 @@
 title: "INLA workshops"
 description: "Slides, code and data used during the INLA workshop"
 author: "Thierry Onkelinx"
-date: 2019-03-10T20:00:00+02:00
+date: 2019-03-10
 categories: ["statistical analysis"]
 tags: ["r", "INLA", "inlabru", "analysis", "mixed model"]
 ---


### PR DESCRIPTION
This PR fixes #99 by using the date format as `YYYY-mm-dd`, cfr. https://inbo.github.io/tutorials/create_tutorial/#using-git-or-github-desktop-rstudio

Moreover, the category is adapted to one of the categories provided by the website setup instead of a custom one. See the enlisted categories [here](https://github.com/inbo/tutorials/blob/master/static/list_of_categories) and the explanation [here](https://inbo.github.io/tutorials/create_tutorial/#writing-a-tutorial). 

@ThierryO feel free to merge if ok. Thanks a lot for the contribution to the website. 

If possible, can you provide a short introduction or context about INLA and the workshop material? Currently, it is hard to the reader to understand potential usefulness when seeing the material:
![image](https://user-images.githubusercontent.com/754862/54088831-7036b400-4362-11e9-8757-77b453af718a.png)
