### PR TITLE
Git workflow: extend title

### DIFF
--- a/content/tutorials/git_workflow/index.md
+++ b/content/tutorials/git_workflow/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Git workflow"
+title: "Git workflow using the command line"
 description: "Git workflow using the command line"
 author: "Stijn Van Hoey"
 date: 2017-10-18T14:42:43+02:00


### PR DESCRIPTION
In order to make a better distinction with the 'Git(hub) introduction' tutorial, I propose to make the title more specific. This will cause less confusion when looking at the list of git-tutorials at https://inbo.github.io/tutorials/tags/git/