### PR TITLE
Include tutorial descriptions in lists + style

### DIFF
--- a/layouts/_default/li.html
+++ b/layouts/_default/li.html
@@ -1,0 +1,13 @@
+<li class='item'>
+  <div class='meta'>
+    {{ partial "list/date" . }}
+  </div>
+  <header class='item-header'>
+    <h3 class='item-title'>
+      <a href='{{ .Permalink | relURL }}'>
+        {{- .Title -}}
+      </a>
+    </h3>
+    <p class='description'>{{ .Description | safeHTML | truncate 150 }}</p>
+  </header>
+</li>

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -29,6 +29,12 @@
             text-decoration: underline;
         }
 
+    /* Style descriptions (set in layouts/_default/li.html) */
+    #content .item .description {
+        font-size: 80%;
+        margin: 0;
+    }
+
     /* Style anchor links (set in layouts/partials/entry.html) */
     #content .anchor {
         margin-left: 10px;


### PR DESCRIPTION
Closes #132. Adds the `description` to page lists:

<img width="726" alt="Screenshot 2019-06-18 at 16 03 27" src="https://user-images.githubusercontent.com/600993/59690990-a0ec7c00-91e2-11e9-8019-ba44c93d8bb4.png">

Font size is 85% and descriptions are smartly truncated at 150 characters (with `...` for more content).