### PR TITLE
Update tutorial about match names against GBIF backbone

### DIFF
--- a/content/tutorials/r_gbif_name_matching/index.Rmd
+++ b/content/tutorials/r_gbif_name_matching/index.Rmd
@@ -1,6 +1,6 @@
 ---
-title: "Match scientific names with the GBIF backbone"
-author: "Dirk Maes, Dimitri Brosens"
+title: "Match scientific names with the GBIF Backbone Taxonomy"
+author: "Dirk Maes, Dimitri Brosens, Damiano Oldoni"
 date: 2018-06-14
 categories: ["r"]
 tags: ["api", "webservice", "r", "gbif", "biodiversity"]
@@ -12,14 +12,19 @@ output:
 
 ## Introduction
 
-This tutorial will explain how you can match a list of 'scientific names' to the GBIF taxonomic backbone
+This tutorial will explain how you can match a list of _scientific names_ against the [GBIF backbone taxonomy](https://www.gbif.org/dataset/d7dddbf4-2cf0-4f39-9b2a-bb099caae36c).
 
-Important is that you have [rgbif](https://github.com/ropensci/rgbif) and [inborutils](https://inbo.github.io/inborutils/) installed and available:
+Important is that you have the most recent version of [rgbif](https://github.com/ropensci/rgbif) and [inborutils](https://inbo.github.io/inborutils/) installed and available:
 
-```{r message=FALSE, warning=FALSE}
-library(tidyverse) # tidyverse
-library(rgbif)     # To Match GBIF
-library(inborutils) # wrap GBIF api data
+```{r install_pkgs, eval=FALSE}
+devtools::install_github("ropensci/rgbif")    # install rgbif
+devtools::install_github("inbo/inboruilts")   # install inboruilts
+```
+
+```{r load_libraries, message=FALSE, warning=FALSE}
+library(tidyverse)    # tidyverse
+library(rgbif)        # To Match GBIF
+library(inborutils)   # wrap GBIF API data
 library(knitr)
 ```
 
@@ -27,55 +32,70 @@ library(knitr)
 
 Read file containing the scientific names you want to check against the [GBIF](https://www.gbif.org/species/search?q=) taxonomic backbone:
 
-```{r}
+```{r read_species_list}
 species_list <- read_csv("https://raw.githubusercontent.com/inbo/inbo-pyutils/master/gbif/gbif_name_match/sample.csv", trim_ws = TRUE, col_types = cols())
 ```
    
 Take a look at the data:
 
-```{r}
-knitr::kable(head(species_list))
+```{r preview_species_list}
+knitr::kable(species_list)
 ```
 
-## Request species information
+## Request taxonomic information
 
-Match the column containing the scientificName with GBIF, using the `gbif_species_name_match` function from the [inborutils](https://inbo.github.io/inborutils/reference/gbif_species_name_match.html) package:
+Match the column containing the scientific name with GBIF, using the `gbif_species_name_match` function from the [inborutils](https://inbo.github.io/inborutils/reference/gbif_species_name_match.html) package:
 
 ```{r, message=FALSE, warning=FALSE}
 species_list_matched <- species_list %>% 
-    gbif_species_name_match(name_col = "name") 
+    gbif_species_name_match(name = "name") 
 ```
 
-The `name_col` argument is the column name containing the scientific names. 
+The `name` argument is the column name containing the scientific names. Default value: `name`. So, the code above is equivalent to:
+
+```{r similar_code, eval=FALSE}
+species_list_matched <- species_list %>% 
+    gbif_species_name_match() 
+```
+
+By default, `gbif_species_name_match` returns the following GBIF fields: `usageKey`, `scientificName`, `rank`, `order`, `matchType`, `phylum`, `kingdom`, `genus`, `class`, `confidence`, `synonym`, `status`, `family`.
 
 Take a look at the updated data:
 
-```{r}
-knitr::kable(head(species_list_matched))
+```{r view_output}
+knitr::kable(species_list_matched)
 ```
 
-You can also specify which info (`gbif_terms`) GBIF should return. For example, return a lot of terms: 
+Notice that GBIF fields whose name is already used as column name are automatically renamed by adding suffix  `1`. In our case, input data.frame `species_list` contains already a column called `kingdom`: the GBIF kingdom values are returned in column `kingdom1`:
+
+```{r zoom_kingdom}
+species_list_matched %>% select(kingdom, kingdom1)
+```
+
+You can specify which GBIF fields you would like to have:
 
 ```{r, message=FALSE, warning=FALSE}
 species_list %>% 
-    gbif_species_name_match(name_col = "name",
-                            gbif_terms = c('usageKey', 'scientificName', 
-                                           'rank', 'order', 'matchType', 
-                                           'phylum', 'kingdom', 'genus', 
-                                           'class', 'confidence', 'synonym', 
-                                           'status', 'family')) %>%
-    head() %>%
+    gbif_species_name_match(
+      gbif_terms = c(
+        'scientificName', 
+        'family',
+        'order',
+        'rank',
+        'matchType',
+        'confidence',
+        'status')) %>%
     kable()
 ```
 
-or rather just a subset:
+As `gbif_species_name_match` is a wrapper around rgbif function `name_backbone`, the authors thought important to offer the possibility to pass any parameter of rgbif function `name_backbone`. So, for example, you can set `strict = TRUE` to fuzzy match only the given names, but never a taxon in the upper classification:
 
-```{r, message=FALSE, warning=FALSE}
+```{r example_strict, message=FALSE, warning=FALSE}
 species_list %>% 
-    gbif_species_name_match(name_col = "name",
-                            gbif_terms = c('scientificName', 'family',
-                                           'order', 'matchType')) %>%
-    head() %>%
+    gbif_species_name_match(strict = TRUE) %>%
     kable()
 ```
 
+All accepted parameters of `name_backbone`: 'rank', 'kingdom', 'phylum', 'class', 'order', 'family', 'genus', 'strict', 'verbose', 'start', 'limit', 'curlopts'. See `?name_backbone` for more details.
+
+For Python users, there is a similar (but no longer maintained) [function](https://github.com/inbo/inbo-pyutils/tree/master/gbif/gbif_name_match) in `inbo-pyutils`.

--- a/content/tutorials/r_gbif_name_matching/index.Rmd
+++ b/content/tutorials/r_gbif_name_matching/index.Rmd
@@ -38,7 +38,7 @@ species_list <- read_csv("https://raw.githubusercontent.com/inbo/inbo-pyutils/ma
 Take a look at the data:
 
 ```{r preview_species_list}
-knitr::kable(species_list)
+kable(species_list)
 ```
 
 ## Request taxonomic information
@@ -62,7 +62,7 @@ By default, `gbif_species_name_match` returns the following GBIF fields: `usageK
 Take a look at the updated data:
 
 ```{r view_output}
-knitr::kable(species_list_matched)
+kable(species_list_matched)
 ```
 
 Notice that GBIF fields whose name is already used as column name are automatically renamed by adding suffix  `1`. In our case, input data.frame `species_list` contains already a column called `kingdom`: the GBIF kingdom values are returned in column `kingdom1`:

--- a/content/tutorials/r_gbif_name_matching/index.Rmd
+++ b/content/tutorials/r_gbif_name_matching/index.Rmd
@@ -21,9 +21,9 @@ devtools::install_github("inbo/inboruilts")   # install inboruilts
 ```
 
 ```{r load_libraries, message=FALSE, warning=FALSE}
-library(tidyverse)    # tidyverse
-library(rgbif)        # To Match GBIF
-library(inborutils)   # wrap GBIF API data
+library(tidyverse)    # To do datascience
+library(rgbif)        # To lookup names in the GBIF backbone taxonomy
+library(inborutils)   # To wrap GBIF API data
 library(knitr)
 ```
 

--- a/content/tutorials/r_gbif_name_matching/index.Rmd
+++ b/content/tutorials/r_gbif_name_matching/index.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Match scientific names with the GBIF Backbone Taxonomy"
 author: "Dirk Maes, Dimitri Brosens, Damiano Oldoni"
-date: 2018-06-14
+date: 2019-08-21
 categories: ["r"]
 tags: ["api", "webservice", "r", "gbif", "biodiversity"]
 output: 

--- a/content/tutorials/r_gbif_name_matching/index.Rmd
+++ b/content/tutorials/r_gbif_name_matching/index.Rmd
@@ -17,7 +17,7 @@ This tutorial will explain how you can match a list of _scientific names_ agains
 Important is that you have the most recent version of [inborutils](https://inbo.github.io/inborutils/) installed and available:
 
 ```{r install_pkgs, eval=FALSE}
-devtools::install_github("inbo/inboruilts")   # install inboruilts
+remotes::install_github("inbo/inborutils")   # install inborutils
 ```
 
 ```{r load_libraries, message=FALSE, warning=FALSE}

--- a/content/tutorials/r_gbif_name_matching/index.Rmd
+++ b/content/tutorials/r_gbif_name_matching/index.Rmd
@@ -89,8 +89,8 @@ species_list %>%
     kable()
 ```
 
-As `gbif_species_name_match` is a wrapper around rgbif function `name_backbone`, the authors thought important to offer the possibility to pass any parameter of rgbif function `name_backbone`. 
-So, for example, you can set `strict = TRUE` to fuzzy match only the given names, but never a taxon in the upper classification:
+The function `inborutils::gbif_species_name_match` is a wrapper around `rgbif::name_backbone`, so you can pass any argument of `name_backbone`.
+For example, you can set `strict = TRUE` to fuzzy match only the given names, but never a taxon in the upper classification:
 
 ```{r example_strict, message=FALSE, warning=FALSE}
 species_list %>% 

--- a/content/tutorials/r_gbif_name_matching/index.Rmd
+++ b/content/tutorials/r_gbif_name_matching/index.Rmd
@@ -50,7 +50,8 @@ species_list_matched <- species_list %>%
     gbif_species_name_match(name = "name") 
 ```
 
-The `name` argument is the column name containing the scientific names. Default value: `name`. So, the code above is equivalent to:
+The `name` argument is the column name containing the scientific names. Default value: `name`. 
+So, the code above is equivalent to:
 
 ```{r similar_code, eval=FALSE}
 species_list_matched <- species_list %>% 
@@ -65,7 +66,8 @@ Take a look at the updated data:
 kable(species_list_matched)
 ```
 
-Notice that GBIF fields whose name is already used as column name are automatically renamed by adding suffix  `1`. In our case, input data.frame `species_list` contains already a column called `kingdom`: the GBIF kingdom values are returned in column `kingdom1`:
+Notice that GBIF fields whose name is already used as column name are automatically renamed by adding suffix  `1`. 
+In our case, input data.frame `species_list` contains already a column called `kingdom`: the GBIF kingdom values are returned in column `kingdom1`:
 
 ```{r zoom_kingdom}
 species_list_matched %>% select(kingdom, kingdom1)
@@ -87,7 +89,8 @@ species_list %>%
     kable()
 ```
 
-As `gbif_species_name_match` is a wrapper around rgbif function `name_backbone`, the authors thought important to offer the possibility to pass any parameter of rgbif function `name_backbone`. So, for example, you can set `strict = TRUE` to fuzzy match only the given names, but never a taxon in the upper classification:
+As `gbif_species_name_match` is a wrapper around rgbif function `name_backbone`, the authors thought important to offer the possibility to pass any parameter of rgbif function `name_backbone`. 
+So, for example, you can set `strict = TRUE` to fuzzy match only the given names, but never a taxon in the upper classification:
 
 ```{r example_strict, message=FALSE, warning=FALSE}
 species_list %>% 

--- a/content/tutorials/r_gbif_name_matching/index.Rmd
+++ b/content/tutorials/r_gbif_name_matching/index.Rmd
@@ -14,10 +14,9 @@ output:
 
 This tutorial will explain how you can match a list of _scientific names_ against the [GBIF backbone taxonomy](https://www.gbif.org/dataset/d7dddbf4-2cf0-4f39-9b2a-bb099caae36c).
 
-Important is that you have the most recent version of [rgbif](https://github.com/ropensci/rgbif) and [inborutils](https://inbo.github.io/inborutils/) installed and available:
+Important is that you have the most recent version of [inborutils](https://inbo.github.io/inborutils/) installed and available:
 
 ```{r install_pkgs, eval=FALSE}
-devtools::install_github("ropensci/rgbif")    # install rgbif
 devtools::install_github("inbo/inboruilts")   # install inboruilts
 ```
 

--- a/content/tutorials/r_gbif_name_matching/index.Rmd
+++ b/content/tutorials/r_gbif_name_matching/index.Rmd
@@ -31,52 +31,55 @@ library(knitr)
 
 Read file containing the scientific names you want to check against the [GBIF](https://www.gbif.org/species/search?q=) taxonomic backbone:
 
-```{r read_species_list}
-species_list <- read_csv("https://raw.githubusercontent.com/inbo/inbo-pyutils/master/gbif/gbif_name_match/sample.csv", trim_ws = TRUE, col_types = cols())
+```{r read_species_df}
+species_df <- read_csv("https://raw.githubusercontent.com/inbo/inbo-pyutils/master/gbif/gbif_name_match/sample.csv", trim_ws = TRUE, col_types = cols())
 ```
    
 Take a look at the data:
 
-```{r preview_species_list}
-kable(species_list)
+```{r preview_species_df}
+kable(species_df)
 ```
 
 ## Request taxonomic information
 
-Match the column containing the scientific name with GBIF, using the `gbif_species_name_match` function from the [inborutils](https://inbo.github.io/inborutils/reference/gbif_species_name_match.html) package:
+Given a data.frame, you can match the column containing the scientific name against GBIF Backbone Taxonomy, using the [`gbif_species_name_match`](https://inbo.github.io/inborutils/reference/gbif_species_name_match.html) function from the [inborutils](https://inbo.github.io/inborutils/) package. You need to pass a data.frame, `df` and a column name, `name`:
 
 ```{r use_function_first_time, message=FALSE, warning=FALSE}
-species_list_matched <- species_list %>% 
-    gbif_species_name_match(name = "name") 
+species_df_matched <- gbif_species_name_match(df = species_df, name = "name")
 ```
 
-The `name` argument is the column name containing the scientific names. Default value: `name`. 
-So, the code above is equivalent to:
+As the `name` argument has `"name"` as default value, the code above is equivalent to:
 
 ```{r similar_code, eval=FALSE}
-species_list_matched <- species_list %>% 
-    gbif_species_name_match() 
+species_df_matched <- gbif_species_name_match(species_df)
 ```
 
-By default, `gbif_species_name_match` returns the following GBIF fields: `usageKey`, `scientificName`, `rank`, `order`, `matchType`, `phylum`, `kingdom`, `genus`, `class`, `confidence`, `synonym`, `status`, `family`.
+or using pipe `%>%`:
+
+```{r similar_code_with_pipe, eval=FALSE}
+species_df_matched <- species_df_matched %>% gbif_species_name_match()
+```
+
+By default `gbif_species_name_match` returns the following GBIF fields: `usageKey`, `scientificName`, `rank`, `order`, `matchType`, `phylum`, `kingdom`, `genus`, `class`, `confidence`, `synonym`, `status`, `family`.
 
 Take a look at the updated data:
 
 ```{r view_output}
-kable(species_list_matched)
+kable(species_df_matched)
 ```
 
 Notice that GBIF fields whose name is already used as column name are automatically renamed by adding suffix  `1`. 
-In our case, input data.frame `species_list` contains already a column called `kingdom`: the GBIF kingdom values are returned in column `kingdom1`:
+In our case, input data.frame `species_df` contains already a column called `kingdom`. The GBIF kingdom values are returned in column `kingdom1`:
 
 ```{r zoom_kingdom}
-species_list_matched %>% select(kingdom, kingdom1)
+species_df_matched %>% select(kingdom, kingdom1)
 ```
 
-You can specify which GBIF fields you would like to have:
+You can also specify which GBIF fields you would like to have:
 
 ```{r, message=FALSE, warning=FALSE}
-species_list %>% 
+species_df %>% 
     gbif_species_name_match(
       gbif_terms = c(
         'scientificName', 
@@ -93,11 +96,11 @@ The function `inborutils::gbif_species_name_match` is a wrapper around `rgbif::n
 For example, you can set `strict = TRUE` to fuzzy match only the given names, but never a taxon in the upper classification:
 
 ```{r example_strict, message=FALSE, warning=FALSE}
-species_list %>% 
+species_df %>% 
     gbif_species_name_match(strict = TRUE) %>%
     kable()
 ```
 
-All accepted parameters of `name_backbone`: 'rank', 'kingdom', 'phylum', 'class', 'order', 'family', 'genus', 'strict', 'verbose', 'start', 'limit', 'curlopts'. See `?name_backbone` for more details.
+These are all accepted parameters of `name_backbone`: 'rank', 'kingdom', 'phylum', 'class', 'order', 'family', 'genus', 'strict', 'verbose', 'start', 'limit', 'curlopts'. See `?name_backbone` for more details.
 
 For Python users, there is a similar (but no longer maintained) [function](https://github.com/inbo/inbo-pyutils/tree/master/gbif/gbif_name_match) in `inbo-pyutils`.

--- a/content/tutorials/r_gbif_name_matching/index.Rmd
+++ b/content/tutorials/r_gbif_name_matching/index.Rmd
@@ -12,7 +12,7 @@ output:
 
 ## Introduction
 
-This tutorial will explain how you can match a list of _scientific names_ against the [GBIF backbone taxonomy](https://www.gbif.org/dataset/d7dddbf4-2cf0-4f39-9b2a-bb099caae36c).
+This tutorial will explain how you can match a list of _scientific names_ against the [GBIF backbone taxonomy](https://www.gbif.org/species/search?dataset_key=d7dddbf4-2cf0-4f39-9b2a-bb099caae36c&advanced=1).
 
 It is important that you have the most recent version of [inborutils](https://inbo.github.io/inborutils/) installed and available:
 

--- a/content/tutorials/r_gbif_name_matching/index.Rmd
+++ b/content/tutorials/r_gbif_name_matching/index.Rmd
@@ -14,7 +14,7 @@ output:
 
 This tutorial will explain how you can match a list of _scientific names_ against the [GBIF backbone taxonomy](https://www.gbif.org/dataset/d7dddbf4-2cf0-4f39-9b2a-bb099caae36c).
 
-Important is that you have the most recent version of [inborutils](https://inbo.github.io/inborutils/) installed and available:
+It is important that you have the most recent version of [inborutils](https://inbo.github.io/inborutils/) installed and available:
 
 ```{r install_pkgs, eval=FALSE}
 remotes::install_github("inbo/inborutils")   # install inborutils

--- a/content/tutorials/r_gbif_name_matching/index.Rmd
+++ b/content/tutorials/r_gbif_name_matching/index.Rmd
@@ -45,7 +45,7 @@ kable(species_list)
 
 Match the column containing the scientific name with GBIF, using the `gbif_species_name_match` function from the [inborutils](https://inbo.github.io/inborutils/reference/gbif_species_name_match.html) package:
 
-```{r, message=FALSE, warning=FALSE}
+```{r use_function_first_time, message=FALSE, warning=FALSE}
 species_list_matched <- species_list %>% 
     gbif_species_name_match(name = "name") 
 ```

--- a/content/tutorials/r_gbif_name_matching/index.md
+++ b/content/tutorials/r_gbif_name_matching/index.md
@@ -15,7 +15,7 @@ Introduction
 
 This tutorial will explain how you can match a list of *scientific
 names* against the [GBIF backbone
-taxonomy](https://www.gbif.org/dataset/d7dddbf4-2cf0-4f39-9b2a-bb099caae36c).
+taxonomy](https://www.gbif.org/species/search?dataset_key=d7dddbf4-2cf0-4f39-9b2a-bb099caae36c&advanced=1).
 
 It is important that you have the most recent version of
 [inborutils](https://inbo.github.io/inborutils/) installed and

--- a/content/tutorials/r_gbif_name_matching/index.md
+++ b/content/tutorials/r_gbif_name_matching/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Match scientific names with the GBIF Backbone Taxonomy"
 author: "Dirk Maes, Dimitri Brosens, Damiano Oldoni"
-date: 2018-06-14
+date: 2019-08-21
 categories: ["r"]
 tags: ["api", "webservice", "r", "gbif", "biodiversity"]
 output: 
@@ -90,13 +90,13 @@ Take a look at the updated data:
 kable(species_list_matched)
 ```
 
-| name                      | kingdom  | euConcernStatus     |  usageKey| scientificName                              | rank    | order        | matchType | phylum       | kingdom1 | genus       | class         |  confidence| synonym | status   | family     |
-|:--------------------------|:---------|:--------------------|---------:|:--------------------------------------------|:--------|:-------------|:----------|:-------------|:---------|:------------|:--------------|-----------:|:--------|:---------|:-----------|
-| Alopochen aegyptiaca      | Animalia | under consideration |   2498252| Alopochen aegyptiaca (Linnaeus, 1766)       | SPECIES | Anseriformes | EXACT     | Chordata     | Animalia | Alopochen   | Aves          |          98| FALSE   | ACCEPTED | Anatidae   |
-| Cotoneaster ganghobaensis | Plantae  | NA                  |   3025989| Cotoneaster ganghobaensis J.Fryer & B.Hylmö | SPECIES | Rosales      | EXACT     | Tracheophyta | Plantae  | Cotoneaster | Magnoliopsida |          98| FALSE   | ACCEPTED | Rosaceae   |
-| Cotoneaster hylmoei       | Plantae  | NA                  |   3025758| Cotoneaster hylmoei K.E.Flinck & J.Fryer    | SPECIES | Rosales      | EXACT     | Tracheophyta | Plantae  | Cotoneaster | Magnoliopsida |          98| FALSE   | ACCEPTED | Rosaceae   |
-| Cotoneaster x suecicus    | Plantae  | NA                  |   3026040| Cotoneaster suecicus G.Klotz                | SPECIES | Rosales      | EXACT     | Tracheophyta | Plantae  | Cotoneaster | Magnoliopsida |          98| FALSE   | ACCEPTED | Rosaceae   |
-| Euthamia graminifolia     | Plantae  | under preparation   |   3092782| Euthamia graminifolia (L.) Nutt.            | SPECIES | Asterales    | EXACT     | Tracheophyta | Plantae  | Euthamia    | Magnoliopsida |          98| FALSE   | ACCEPTED | Asteraceae |
+| name                      | kingdom  | euConcernStatus     |  usageKey| scientificName                               | rank    | order        | matchType | phylum       | kingdom1 | genus       | class         |  confidence| synonym | status   | family     |
+|:--------------------------|:---------|:--------------------|---------:|:---------------------------------------------|:--------|:-------------|:----------|:-------------|:---------|:------------|:--------------|-----------:|:--------|:---------|:-----------|
+| Alopochen aegyptiaca      | Animalia | under consideration |   2498252| Alopochen aegyptiaca (Linnaeus, 1766)        | SPECIES | Anseriformes | EXACT     | Chordata     | Animalia | Alopochen   | Aves          |          98| FALSE   | ACCEPTED | Anatidae   |
+| Cotoneaster ganghobaensis | Plantae  | NA                  |   3025989| Cotoneaster ganghobaensis J.Fryer & B.HylmÃ¶ | SPECIES | Rosales      | EXACT     | Tracheophyta | Plantae  | Cotoneaster | Magnoliopsida |          98| FALSE   | ACCEPTED | Rosaceae   |
+| Cotoneaster hylmoei       | Plantae  | NA                  |   3025758| Cotoneaster hylmoei K.E.Flinck & J.Fryer     | SPECIES | Rosales      | EXACT     | Tracheophyta | Plantae  | Cotoneaster | Magnoliopsida |          98| FALSE   | ACCEPTED | Rosaceae   |
+| Cotoneaster x suecicus    | Plantae  | NA                  |   3026040| Cotoneaster suecicus G.Klotz                 | SPECIES | Rosales      | EXACT     | Tracheophyta | Plantae  | Cotoneaster | Magnoliopsida |          98| FALSE   | ACCEPTED | Rosaceae   |
+| Euthamia graminifolia     | Plantae  | under preparation   |   3092782| Euthamia graminifolia (L.) Nutt.             | SPECIES | Asterales    | EXACT     | Tracheophyta | Plantae  | Euthamia    | Magnoliopsida |          98| FALSE   | ACCEPTED | Asteraceae |
 
 Notice that GBIF fields whose name is already used as column name are
 automatically renamed by adding suffix `1`. In our case, input
@@ -134,13 +134,13 @@ species_list %>%
 
     ## [1] "All column names present"
 
-| name                      | kingdom  | euConcernStatus     | scientificName                              | family     | order        | rank    | matchType |  confidence| status   |
-|:--------------------------|:---------|:--------------------|:--------------------------------------------|:-----------|:-------------|:--------|:----------|-----------:|:---------|
-| Alopochen aegyptiaca      | Animalia | under consideration | Alopochen aegyptiaca (Linnaeus, 1766)       | Anatidae   | Anseriformes | SPECIES | EXACT     |          98| ACCEPTED |
-| Cotoneaster ganghobaensis | Plantae  | NA                  | Cotoneaster ganghobaensis J.Fryer & B.Hylmö | Rosaceae   | Rosales      | SPECIES | EXACT     |          98| ACCEPTED |
-| Cotoneaster hylmoei       | Plantae  | NA                  | Cotoneaster hylmoei K.E.Flinck & J.Fryer    | Rosaceae   | Rosales      | SPECIES | EXACT     |          98| ACCEPTED |
-| Cotoneaster x suecicus    | Plantae  | NA                  | Cotoneaster suecicus G.Klotz                | Rosaceae   | Rosales      | SPECIES | EXACT     |          98| ACCEPTED |
-| Euthamia graminifolia     | Plantae  | under preparation   | Euthamia graminifolia (L.) Nutt.            | Asteraceae | Asterales    | SPECIES | EXACT     |          98| ACCEPTED |
+| name                      | kingdom  | euConcernStatus     | scientificName                               | family     | order        | rank    | matchType |  confidence| status   |
+|:--------------------------|:---------|:--------------------|:---------------------------------------------|:-----------|:-------------|:--------|:----------|-----------:|:---------|
+| Alopochen aegyptiaca      | Animalia | under consideration | Alopochen aegyptiaca (Linnaeus, 1766)        | Anatidae   | Anseriformes | SPECIES | EXACT     |          98| ACCEPTED |
+| Cotoneaster ganghobaensis | Plantae  | NA                  | Cotoneaster ganghobaensis J.Fryer & B.HylmÃ¶ | Rosaceae   | Rosales      | SPECIES | EXACT     |          98| ACCEPTED |
+| Cotoneaster hylmoei       | Plantae  | NA                  | Cotoneaster hylmoei K.E.Flinck & J.Fryer     | Rosaceae   | Rosales      | SPECIES | EXACT     |          98| ACCEPTED |
+| Cotoneaster x suecicus    | Plantae  | NA                  | Cotoneaster suecicus G.Klotz                 | Rosaceae   | Rosales      | SPECIES | EXACT     |          98| ACCEPTED |
+| Euthamia graminifolia     | Plantae  | under preparation   | Euthamia graminifolia (L.) Nutt.             | Asteraceae | Asterales    | SPECIES | EXACT     |          98| ACCEPTED |
 
 The function `inborutils::gbif_species_name_match` is a wrapper around
 `rgbif::name_backbone`, so you can pass any argument of `name_backbone`.
@@ -155,13 +155,13 @@ species_list %>%
 
     ## [1] "All column names present"
 
-| name                      | kingdom  | euConcernStatus     |  usageKey| scientificName                              | rank    | order        | matchType | phylum       | kingdom1 | genus       | class         |  confidence| synonym | status   | family     |
-|:--------------------------|:---------|:--------------------|---------:|:--------------------------------------------|:--------|:-------------|:----------|:-------------|:---------|:------------|:--------------|-----------:|:--------|:---------|:-----------|
-| Alopochen aegyptiaca      | Animalia | under consideration |   2498252| Alopochen aegyptiaca (Linnaeus, 1766)       | SPECIES | Anseriformes | EXACT     | Chordata     | Animalia | Alopochen   | Aves          |          99| FALSE   | ACCEPTED | Anatidae   |
-| Cotoneaster ganghobaensis | Plantae  | NA                  |   3025989| Cotoneaster ganghobaensis J.Fryer & B.Hylmö | SPECIES | Rosales      | EXACT     | Tracheophyta | Plantae  | Cotoneaster | Magnoliopsida |          99| FALSE   | ACCEPTED | Rosaceae   |
-| Cotoneaster hylmoei       | Plantae  | NA                  |   3025758| Cotoneaster hylmoei K.E.Flinck & J.Fryer    | SPECIES | Rosales      | EXACT     | Tracheophyta | Plantae  | Cotoneaster | Magnoliopsida |          99| FALSE   | ACCEPTED | Rosaceae   |
-| Cotoneaster x suecicus    | Plantae  | NA                  |   3026040| Cotoneaster suecicus G.Klotz                | SPECIES | Rosales      | EXACT     | Tracheophyta | Plantae  | Cotoneaster | Magnoliopsida |          99| FALSE   | ACCEPTED | Rosaceae   |
-| Euthamia graminifolia     | Plantae  | under preparation   |   3092782| Euthamia graminifolia (L.) Nutt.            | SPECIES | Asterales    | EXACT     | Tracheophyta | Plantae  | Euthamia    | Magnoliopsida |          98| FALSE   | ACCEPTED | Asteraceae |
+| name                      | kingdom  | euConcernStatus     |  usageKey| scientificName                               | rank    | order        | matchType | phylum       | kingdom1 | genus       | class         |  confidence| synonym | status   | family     |
+|:--------------------------|:---------|:--------------------|---------:|:---------------------------------------------|:--------|:-------------|:----------|:-------------|:---------|:------------|:--------------|-----------:|:--------|:---------|:-----------|
+| Alopochen aegyptiaca      | Animalia | under consideration |   2498252| Alopochen aegyptiaca (Linnaeus, 1766)        | SPECIES | Anseriformes | EXACT     | Chordata     | Animalia | Alopochen   | Aves          |          99| FALSE   | ACCEPTED | Anatidae   |
+| Cotoneaster ganghobaensis | Plantae  | NA                  |   3025989| Cotoneaster ganghobaensis J.Fryer & B.HylmÃ¶ | SPECIES | Rosales      | EXACT     | Tracheophyta | Plantae  | Cotoneaster | Magnoliopsida |          99| FALSE   | ACCEPTED | Rosaceae   |
+| Cotoneaster hylmoei       | Plantae  | NA                  |   3025758| Cotoneaster hylmoei K.E.Flinck & J.Fryer     | SPECIES | Rosales      | EXACT     | Tracheophyta | Plantae  | Cotoneaster | Magnoliopsida |          99| FALSE   | ACCEPTED | Rosaceae   |
+| Cotoneaster x suecicus    | Plantae  | NA                  |   3026040| Cotoneaster suecicus G.Klotz                 | SPECIES | Rosales      | EXACT     | Tracheophyta | Plantae  | Cotoneaster | Magnoliopsida |          99| FALSE   | ACCEPTED | Rosaceae   |
+| Euthamia graminifolia     | Plantae  | under preparation   |   3092782| Euthamia graminifolia (L.) Nutt.             | SPECIES | Asterales    | EXACT     | Tracheophyta | Plantae  | Euthamia    | Magnoliopsida |          98| FALSE   | ACCEPTED | Asteraceae |
 
 All accepted parameters of `name_backbone`: ‘rank’, ‘kingdom’, ‘phylum’,
 ‘class’, ‘order’, ‘family’, ‘genus’, ‘strict’, ‘verbose’, ‘start’,

--- a/content/tutorials/r_gbif_name_matching/index.md
+++ b/content/tutorials/r_gbif_name_matching/index.md
@@ -18,12 +18,10 @@ names* against the [GBIF backbone
 taxonomy](https://www.gbif.org/dataset/d7dddbf4-2cf0-4f39-9b2a-bb099caae36c).
 
 Important is that you have the most recent version of
-[rgbif](https://github.com/ropensci/rgbif) and
 [inborutils](https://inbo.github.io/inborutils/) installed and
 available:
 
 ``` r
-devtools::install_github("ropensci/rgbif")    # install rgbif
 devtools::install_github("inbo/inboruilts")   # install inboruilts
 ```
 

--- a/content/tutorials/r_gbif_name_matching/index.md
+++ b/content/tutorials/r_gbif_name_matching/index.md
@@ -39,13 +39,13 @@ Read file containing the scientific names you want to check against the
 [GBIF](https://www.gbif.org/species/search?q=) taxonomic backbone:
 
 ``` r
-species_list <- read_csv("https://raw.githubusercontent.com/inbo/inbo-pyutils/master/gbif/gbif_name_match/sample.csv", trim_ws = TRUE, col_types = cols())
+species_df <- read_csv("https://raw.githubusercontent.com/inbo/inbo-pyutils/master/gbif/gbif_name_match/sample.csv", trim_ws = TRUE, col_types = cols())
 ```
 
 Take a look at the data:
 
 ``` r
-kable(species_list)
+kable(species_df)
 ```
 
 | name                      | kingdom  | euConcernStatus     |
@@ -59,27 +59,32 @@ kable(species_list)
 Request taxonomic information
 -----------------------------
 
-Match the column containing the scientific name with GBIF, using the
-`gbif_species_name_match` function from the
-[inborutils](https://inbo.github.io/inborutils/reference/gbif_species_name_match.html)
-package:
+Given a data.frame, you can match the column containing the scientific
+name against GBIF Backbone Taxonomy, using the
+[`gbif_species_name_match`](https://inbo.github.io/inborutils/reference/gbif_species_name_match.html)
+function from the [inborutils](https://inbo.github.io/inborutils/)
+package. You need to pass a data.frame, `df` and a column name, `name`:
 
 ``` r
-species_list_matched <- species_list %>% 
-    gbif_species_name_match(name = "name") 
+species_df_matched <- gbif_species_name_match(df = species_df, name = "name")
 ```
 
     ## [1] "All column names present"
 
-The `name` argument is the column name containing the scientific names.
-Default value: `name`. So, the code above is equivalent to:
+As the `name` argument has `"name"` as default value, the code above is
+equivalent to:
 
 ``` r
-species_list_matched <- species_list %>% 
-    gbif_species_name_match() 
+species_df_matched <- gbif_species_name_match(species_df)
 ```
 
-By default, `gbif_species_name_match` returns the following GBIF fields:
+or using pipe `%>%`:
+
+``` r
+species_df_matched <- species_df_matched %>% gbif_species_name_match()
+```
+
+By default `gbif_species_name_match` returns the following GBIF fields:
 `usageKey`, `scientificName`, `rank`, `order`, `matchType`, `phylum`,
 `kingdom`, `genus`, `class`, `confidence`, `synonym`, `status`,
 `family`.
@@ -87,7 +92,7 @@ By default, `gbif_species_name_match` returns the following GBIF fields:
 Take a look at the updated data:
 
 ``` r
-kable(species_list_matched)
+kable(species_df_matched)
 ```
 
 | name                      | kingdom  | euConcernStatus     |  usageKey| scientificName                               | rank    | order        | matchType | phylum       | kingdom1 | genus       | class         |  confidence| synonym | status   | family     |
@@ -100,11 +105,11 @@ kable(species_list_matched)
 
 Notice that GBIF fields whose name is already used as column name are
 automatically renamed by adding suffix `1`. In our case, input
-data.frame `species_list` contains already a column called `kingdom`:
-the GBIF kingdom values are returned in column `kingdom1`:
+data.frame `species_df` contains already a column called `kingdom`. The
+GBIF kingdom values are returned in column `kingdom1`:
 
 ``` r
-species_list_matched %>% select(kingdom, kingdom1)
+species_df_matched %>% select(kingdom, kingdom1)
 ```
 
     ## # A tibble: 5 x 2
@@ -116,10 +121,10 @@ species_list_matched %>% select(kingdom, kingdom1)
     ## 4 Plantae  Plantae 
     ## 5 Plantae  Plantae
 
-You can specify which GBIF fields you would like to have:
+You can also specify which GBIF fields you would like to have:
 
 ``` r
-species_list %>% 
+species_df %>% 
     gbif_species_name_match(
       gbif_terms = c(
         'scientificName', 
@@ -148,7 +153,7 @@ For example, you can set `strict = TRUE` to fuzzy match only the given
 names, but never a taxon in the upper classification:
 
 ``` r
-species_list %>% 
+species_df %>% 
     gbif_species_name_match(strict = TRUE) %>%
     kable()
 ```
@@ -163,9 +168,9 @@ species_list %>%
 | Cotoneaster x suecicus    | Plantae  | NA                  |   3026040| Cotoneaster suecicus G.Klotz                 | SPECIES | Rosales      | EXACT     | Tracheophyta | Plantae  | Cotoneaster | Magnoliopsida |          99| FALSE   | ACCEPTED | Rosaceae   |
 | Euthamia graminifolia     | Plantae  | under preparation   |   3092782| Euthamia graminifolia (L.) Nutt.             | SPECIES | Asterales    | EXACT     | Tracheophyta | Plantae  | Euthamia    | Magnoliopsida |          98| FALSE   | ACCEPTED | Asteraceae |
 
-All accepted parameters of `name_backbone`: ‘rank’, ‘kingdom’, ‘phylum’,
-‘class’, ‘order’, ‘family’, ‘genus’, ‘strict’, ‘verbose’, ‘start’,
-‘limit’, ‘curlopts’. See `?name_backbone` for more details.
+These are all accepted parameters of `name_backbone`: ‘rank’, ‘kingdom’,
+‘phylum’, ‘class’, ‘order’, ‘family’, ‘genus’, ‘strict’, ‘verbose’,
+‘start’, ‘limit’, ‘curlopts’. See `?name_backbone` for more details.
 
 For Python users, there is a similar (but no longer maintained)
 [function](https://github.com/inbo/inbo-pyutils/tree/master/gbif/gbif_name_match)

--- a/content/tutorials/r_gbif_name_matching/index.md
+++ b/content/tutorials/r_gbif_name_matching/index.md
@@ -142,10 +142,9 @@ species_list %>%
 | Cotoneaster x suecicus    | Plantae  | NA                  | Cotoneaster suecicus G.Klotz                | Rosaceae   | Rosales      | SPECIES | EXACT     |          98| ACCEPTED |
 | Euthamia graminifolia     | Plantae  | under preparation   | Euthamia graminifolia (L.) Nutt.            | Asteraceae | Asterales    | SPECIES | EXACT     |          98| ACCEPTED |
 
-As `gbif_species_name_match` is a wrapper around rgbif function
-`name_backbone`, the authors thought important to offer the possibility
-to pass any parameter of rgbif function `name_backbone`. So, for
-example, you can set `strict = TRUE` to fuzzy match only the given
+The function `inborutils::gbif_species_name_match` is a wrapper around
+`rgbif::name_backbone`, so you can pass any argument of `name_backbone`.
+For example, you can set `strict = TRUE` to fuzzy match only the given
 names, but never a taxon in the upper classification:
 
 ``` r

--- a/content/tutorials/r_gbif_name_matching/index.md
+++ b/content/tutorials/r_gbif_name_matching/index.md
@@ -1,6 +1,6 @@
 ---
-title: "Match scientific names with the GBIF backbone"
-author: "Dirk Maes, Dimitri Brosens"
+title: "Match scientific names with the GBIF Backbone Taxonomy"
+author: "Dirk Maes, Dimitri Brosens, Damiano Oldoni"
 date: 2018-06-14
 categories: ["r"]
 tags: ["api", "webservice", "r", "gbif", "biodiversity"]
@@ -13,21 +13,32 @@ output:
 Introduction
 ------------
 
-This tutorial will explain how you can match a list of 'scientific names' to the GBIF taxonomic backbone
+This tutorial will explain how you can match a list of *scientific
+names* against the [GBIF backbone
+taxonomy](https://www.gbif.org/dataset/d7dddbf4-2cf0-4f39-9b2a-bb099caae36c).
 
-Important is that you have [rgbif](https://github.com/ropensci/rgbif) and [inborutils](https://inbo.github.io/inborutils/) installed and available:
+Important is that you have the most recent version of
+[rgbif](https://github.com/ropensci/rgbif) and
+[inborutils](https://inbo.github.io/inborutils/) installed and
+available:
 
 ``` r
-library(tidyverse) # tidyverse
-library(rgbif)     # To Match GBIF
-library(inborutils) # wrap GBIF api data
+devtools::install_github("ropensci/rgbif")    # install rgbif
+devtools::install_github("inbo/inboruilts")   # install inboruilts
+```
+
+``` r
+library(tidyverse)    # tidyverse
+library(rgbif)        # To Match GBIF
+library(inborutils)   # wrap GBIF API data
 library(knitr)
 ```
 
 Read data file containing the scientific names
 ----------------------------------------------
 
-Read file containing the scientific names you want to check against the [GBIF](https://www.gbif.org/species/search?q=) taxonomic backbone:
+Read file containing the scientific names you want to check against the
+[GBIF](https://www.gbif.org/species/search?q=) taxonomic backbone:
 
 ``` r
 species_list <- read_csv("https://raw.githubusercontent.com/inbo/inbo-pyutils/master/gbif/gbif_name_match/sample.csv", trim_ws = TRUE, col_types = cols())
@@ -36,7 +47,7 @@ species_list <- read_csv("https://raw.githubusercontent.com/inbo/inbo-pyutils/ma
 Take a look at the data:
 
 ``` r
-knitr::kable(head(species_list))
+knitr::kable(species_list)
 ```
 
 | name                      | kingdom  | euConcernStatus     |
@@ -47,75 +58,118 @@ knitr::kable(head(species_list))
 | Cotoneaster x suecicus    | Plantae  | NA                  |
 | Euthamia graminifolia     | Plantae  | under preparation   |
 
-Request species information
----------------------------
+Request taxonomic information
+-----------------------------
 
-Match the column containing the scientificName with GBIF, using the `gbif_species_name_match` function from the [inborutils](https://inbo.github.io/inborutils/reference/gbif_species_name_match.html) package:
+Match the column containing the scientific name with GBIF, using the
+`gbif_species_name_match` function from the
+[inborutils](https://inbo.github.io/inborutils/reference/gbif_species_name_match.html)
+package:
 
 ``` r
 species_list_matched <- species_list %>% 
-    gbif_species_name_match(name_col = "name") 
+    gbif_species_name_match(name = "name") 
 ```
 
     ## [1] "All column names present"
 
-The `name_col` argument is the column name containing the scientific names.
+The `name` argument is the column name containing the scientific names.
+Default value: `name`. So, the code above is equivalent to:
+
+``` r
+species_list_matched <- species_list %>% 
+    gbif_species_name_match() 
+```
+
+By default, `gbif_species_name_match` returns the following GBIF fields:
+`usageKey`, `scientificName`, `rank`, `order`, `matchType`, `phylum`,
+`kingdom`, `genus`, `class`, `confidence`, `synonym`, `status`,
+`family`.
 
 Take a look at the updated data:
 
 ``` r
-knitr::kable(head(species_list_matched))
+knitr::kable(species_list_matched)
 ```
 
-| name                      | kingdom  | euConcernStatus     |  usageKey| scientificName                              | rank    | order        | matchType | phylum       | genus       | class         |  confidence| synonym | status   | family     |
-|:--------------------------|:---------|:--------------------|---------:|:--------------------------------------------|:--------|:-------------|:----------|:-------------|:------------|:--------------|-----------:|:--------|:---------|:-----------|
-| Alopochen aegyptiaca      | Animalia | under consideration |   2498252| Alopochen aegyptiaca (Linnaeus, 1766)       | SPECIES | Anseriformes | EXACT     | Chordata     | Alopochen   | Aves          |          98| FALSE   | ACCEPTED | Anatidae   |
-| Cotoneaster ganghobaensis | Plantae  | NA                  |   3025989| Cotoneaster ganghobaensis J.Fryer & B.Hylmö | SPECIES | Rosales      | EXACT     | Tracheophyta | Cotoneaster | Magnoliopsida |          98| FALSE   | ACCEPTED | Rosaceae   |
-| Cotoneaster hylmoei       | Plantae  | NA                  |   3025758| Cotoneaster hylmoei K.E.Flinck & J.Fryer    | SPECIES | Rosales      | EXACT     | Tracheophyta | Cotoneaster | Magnoliopsida |          98| FALSE   | ACCEPTED | Rosaceae   |
-| Cotoneaster x suecicus    | Plantae  | NA                  |   3026040| Cotoneaster suecicus G.Klotz                | SPECIES | Rosales      | EXACT     | Tracheophyta | Cotoneaster | Magnoliopsida |          98| FALSE   | ACCEPTED | Rosaceae   |
-| Euthamia graminifolia     | Plantae  | under preparation   |   3092782| Euthamia graminifolia (L.) Nutt.            | SPECIES | Asterales    | EXACT     | Tracheophyta | Euthamia    | Magnoliopsida |          98| FALSE   | ACCEPTED | Asteraceae |
+| name                      | kingdom  | euConcernStatus     |  usageKey| scientificName                              | rank    | order        | matchType | phylum       | kingdom1 | genus       | class         |  confidence| synonym | status   | family     |
+|:--------------------------|:---------|:--------------------|---------:|:--------------------------------------------|:--------|:-------------|:----------|:-------------|:---------|:------------|:--------------|-----------:|:--------|:---------|:-----------|
+| Alopochen aegyptiaca      | Animalia | under consideration |   2498252| Alopochen aegyptiaca (Linnaeus, 1766)       | SPECIES | Anseriformes | EXACT     | Chordata     | Animalia | Alopochen   | Aves          |          98| FALSE   | ACCEPTED | Anatidae   |
+| Cotoneaster ganghobaensis | Plantae  | NA                  |   3025989| Cotoneaster ganghobaensis J.Fryer & B.Hylmö | SPECIES | Rosales      | EXACT     | Tracheophyta | Plantae  | Cotoneaster | Magnoliopsida |          98| FALSE   | ACCEPTED | Rosaceae   |
+| Cotoneaster hylmoei       | Plantae  | NA                  |   3025758| Cotoneaster hylmoei K.E.Flinck & J.Fryer    | SPECIES | Rosales      | EXACT     | Tracheophyta | Plantae  | Cotoneaster | Magnoliopsida |          98| FALSE   | ACCEPTED | Rosaceae   |
+| Cotoneaster x suecicus    | Plantae  | NA                  |   3026040| Cotoneaster suecicus G.Klotz                | SPECIES | Rosales      | EXACT     | Tracheophyta | Plantae  | Cotoneaster | Magnoliopsida |          98| FALSE   | ACCEPTED | Rosaceae   |
+| Euthamia graminifolia     | Plantae  | under preparation   |   3092782| Euthamia graminifolia (L.) Nutt.            | SPECIES | Asterales    | EXACT     | Tracheophyta | Plantae  | Euthamia    | Magnoliopsida |          98| FALSE   | ACCEPTED | Asteraceae |
 
-You can also specify which info (`gbif_terms`) GBIF should return. For example, return a lot of terms:
+Notice that GBIF fields whose name is already used as column name are
+automatically renamed by adding suffix `1`. In our case, input
+data.frame `species_list` contains already a column called `kingdom`:
+the GBIF kingdom values are returned in column `kingdom1`:
+
+``` r
+species_list_matched %>% select(kingdom, kingdom1)
+```
+
+    ## # A tibble: 5 x 2
+    ##   kingdom  kingdom1
+    ##   <chr>    <chr>   
+    ## 1 Animalia Animalia
+    ## 2 Plantae  Plantae 
+    ## 3 Plantae  Plantae 
+    ## 4 Plantae  Plantae 
+    ## 5 Plantae  Plantae
+
+You can specify which GBIF fields you would like to have:
 
 ``` r
 species_list %>% 
-    gbif_species_name_match(name_col = "name",
-                            gbif_terms = c('usageKey', 'scientificName', 
-                                           'rank', 'order', 'matchType', 
-                                           'phylum', 'kingdom', 'genus', 
-                                           'class', 'confidence', 'synonym', 
-                                           'status', 'family')) %>%
-    head() %>%
+    gbif_species_name_match(
+      gbif_terms = c(
+        'scientificName', 
+        'family',
+        'order',
+        'rank',
+        'matchType',
+        'confidence',
+        'status')) %>%
     kable()
 ```
 
     ## [1] "All column names present"
 
-| name                      | kingdom  | euConcernStatus     |  usageKey| scientificName                              | rank    | order        | matchType | phylum       | genus       | class         |  confidence| synonym | status   | family     |
-|:--------------------------|:---------|:--------------------|---------:|:--------------------------------------------|:--------|:-------------|:----------|:-------------|:------------|:--------------|-----------:|:--------|:---------|:-----------|
-| Alopochen aegyptiaca      | Animalia | under consideration |   2498252| Alopochen aegyptiaca (Linnaeus, 1766)       | SPECIES | Anseriformes | EXACT     | Chordata     | Alopochen   | Aves          |          98| FALSE   | ACCEPTED | Anatidae   |
-| Cotoneaster ganghobaensis | Plantae  | NA                  |   3025989| Cotoneaster ganghobaensis J.Fryer & B.Hylmö | SPECIES | Rosales      | EXACT     | Tracheophyta | Cotoneaster | Magnoliopsida |          98| FALSE   | ACCEPTED | Rosaceae   |
-| Cotoneaster hylmoei       | Plantae  | NA                  |   3025758| Cotoneaster hylmoei K.E.Flinck & J.Fryer    | SPECIES | Rosales      | EXACT     | Tracheophyta | Cotoneaster | Magnoliopsida |          98| FALSE   | ACCEPTED | Rosaceae   |
-| Cotoneaster x suecicus    | Plantae  | NA                  |   3026040| Cotoneaster suecicus G.Klotz                | SPECIES | Rosales      | EXACT     | Tracheophyta | Cotoneaster | Magnoliopsida |          98| FALSE   | ACCEPTED | Rosaceae   |
-| Euthamia graminifolia     | Plantae  | under preparation   |   3092782| Euthamia graminifolia (L.) Nutt.            | SPECIES | Asterales    | EXACT     | Tracheophyta | Euthamia    | Magnoliopsida |          98| FALSE   | ACCEPTED | Asteraceae |
+| name                      | kingdom  | euConcernStatus     | scientificName                              | family     | order        | rank    | matchType |  confidence| status   |
+|:--------------------------|:---------|:--------------------|:--------------------------------------------|:-----------|:-------------|:--------|:----------|-----------:|:---------|
+| Alopochen aegyptiaca      | Animalia | under consideration | Alopochen aegyptiaca (Linnaeus, 1766)       | Anatidae   | Anseriformes | SPECIES | EXACT     |          98| ACCEPTED |
+| Cotoneaster ganghobaensis | Plantae  | NA                  | Cotoneaster ganghobaensis J.Fryer & B.Hylmö | Rosaceae   | Rosales      | SPECIES | EXACT     |          98| ACCEPTED |
+| Cotoneaster hylmoei       | Plantae  | NA                  | Cotoneaster hylmoei K.E.Flinck & J.Fryer    | Rosaceae   | Rosales      | SPECIES | EXACT     |          98| ACCEPTED |
+| Cotoneaster x suecicus    | Plantae  | NA                  | Cotoneaster suecicus G.Klotz                | Rosaceae   | Rosales      | SPECIES | EXACT     |          98| ACCEPTED |
+| Euthamia graminifolia     | Plantae  | under preparation   | Euthamia graminifolia (L.) Nutt.            | Asteraceae | Asterales    | SPECIES | EXACT     |          98| ACCEPTED |
 
-or rather just a subset:
+As `gbif_species_name_match` is a wrapper around rgbif function
+`name_backbone`, the authors thought important to offer the possibility
+to pass any parameter of rgbif function `name_backbone`. So, for
+example, you can set `strict = TRUE` to fuzzy match only the given
+names, but never a taxon in the upper classification:
 
 ``` r
 species_list %>% 
-    gbif_species_name_match(name_col = "name",
-                            gbif_terms = c('scientificName', 'family',
-                                           'order', 'matchType')) %>%
-    head() %>%
+    gbif_species_name_match(strict = TRUE) %>%
     kable()
 ```
 
     ## [1] "All column names present"
 
-| name                      | kingdom  | euConcernStatus     | scientificName                              | family     | order        | matchType |
-|:--------------------------|:---------|:--------------------|:--------------------------------------------|:-----------|:-------------|:----------|
-| Alopochen aegyptiaca      | Animalia | under consideration | Alopochen aegyptiaca (Linnaeus, 1766)       | Anatidae   | Anseriformes | EXACT     |
-| Cotoneaster ganghobaensis | Plantae  | NA                  | Cotoneaster ganghobaensis J.Fryer & B.Hylmö | Rosaceae   | Rosales      | EXACT     |
-| Cotoneaster hylmoei       | Plantae  | NA                  | Cotoneaster hylmoei K.E.Flinck & J.Fryer    | Rosaceae   | Rosales      | EXACT     |
-| Cotoneaster x suecicus    | Plantae  | NA                  | Cotoneaster suecicus G.Klotz                | Rosaceae   | Rosales      | EXACT     |
-| Euthamia graminifolia     | Plantae  | under preparation   | Euthamia graminifolia (L.) Nutt.            | Asteraceae | Asterales    | EXACT     |
+| name                      | kingdom  | euConcernStatus     |  usageKey| scientificName                              | rank    | order        | matchType | phylum       | kingdom1 | genus       | class         |  confidence| synonym | status   | family     |
+|:--------------------------|:---------|:--------------------|---------:|:--------------------------------------------|:--------|:-------------|:----------|:-------------|:---------|:------------|:--------------|-----------:|:--------|:---------|:-----------|
+| Alopochen aegyptiaca      | Animalia | under consideration |   2498252| Alopochen aegyptiaca (Linnaeus, 1766)       | SPECIES | Anseriformes | EXACT     | Chordata     | Animalia | Alopochen   | Aves          |          99| FALSE   | ACCEPTED | Anatidae   |
+| Cotoneaster ganghobaensis | Plantae  | NA                  |   3025989| Cotoneaster ganghobaensis J.Fryer & B.Hylmö | SPECIES | Rosales      | EXACT     | Tracheophyta | Plantae  | Cotoneaster | Magnoliopsida |          99| FALSE   | ACCEPTED | Rosaceae   |
+| Cotoneaster hylmoei       | Plantae  | NA                  |   3025758| Cotoneaster hylmoei K.E.Flinck & J.Fryer    | SPECIES | Rosales      | EXACT     | Tracheophyta | Plantae  | Cotoneaster | Magnoliopsida |          99| FALSE   | ACCEPTED | Rosaceae   |
+| Cotoneaster x suecicus    | Plantae  | NA                  |   3026040| Cotoneaster suecicus G.Klotz                | SPECIES | Rosales      | EXACT     | Tracheophyta | Plantae  | Cotoneaster | Magnoliopsida |          99| FALSE   | ACCEPTED | Rosaceae   |
+| Euthamia graminifolia     | Plantae  | under preparation   |   3092782| Euthamia graminifolia (L.) Nutt.            | SPECIES | Asterales    | EXACT     | Tracheophyta | Plantae  | Euthamia    | Magnoliopsida |          98| FALSE   | ACCEPTED | Asteraceae |
+
+All accepted parameters of `name_backbone`: ‘rank’, ‘kingdom’, ‘phylum’,
+‘class’, ‘order’, ‘family’, ‘genus’, ‘strict’, ‘verbose’, ‘start’,
+‘limit’, ‘curlopts’. See `?name_backbone` for more details.
+
+For Python users, there is a similar (but no longer maintained)
+[function](https://github.com/inbo/inbo-pyutils/tree/master/gbif/gbif_name_match)
+in `inbo-pyutils`.

--- a/content/tutorials/r_gbif_name_matching/index.md
+++ b/content/tutorials/r_gbif_name_matching/index.md
@@ -45,7 +45,7 @@ species_list <- read_csv("https://raw.githubusercontent.com/inbo/inbo-pyutils/ma
 Take a look at the data:
 
 ``` r
-knitr::kable(species_list)
+kable(species_list)
 ```
 
 | name                      | kingdom  | euConcernStatus     |
@@ -87,7 +87,7 @@ By default, `gbif_species_name_match` returns the following GBIF fields:
 Take a look at the updated data:
 
 ``` r
-knitr::kable(species_list_matched)
+kable(species_list_matched)
 ```
 
 | name                      | kingdom  | euConcernStatus     |  usageKey| scientificName                              | rank    | order        | matchType | phylum       | kingdom1 | genus       | class         |  confidence| synonym | status   | family     |

--- a/content/tutorials/r_gbif_name_matching/index.md
+++ b/content/tutorials/r_gbif_name_matching/index.md
@@ -26,9 +26,9 @@ devtools::install_github("inbo/inboruilts")   # install inboruilts
 ```
 
 ``` r
-library(tidyverse)    # tidyverse
-library(rgbif)        # To Match GBIF
-library(inborutils)   # wrap GBIF API data
+library(tidyverse)    # To do datascience
+library(rgbif)        # To lookup names in the GBIF backbone taxonomy
+library(inborutils)   # To wrap GBIF API data
 library(knitr)
 ```
 

--- a/content/tutorials/r_gbif_name_matching/index.md
+++ b/content/tutorials/r_gbif_name_matching/index.md
@@ -22,7 +22,7 @@ Important is that you have the most recent version of
 available:
 
 ``` r
-devtools::install_github("inbo/inboruilts")   # install inboruilts
+remotes::install_github("inbo/inborutils")   # install inborutils
 ```
 
 ``` r

--- a/content/tutorials/r_gbif_name_matching/index.md
+++ b/content/tutorials/r_gbif_name_matching/index.md
@@ -17,7 +17,7 @@ This tutorial will explain how you can match a list of *scientific
 names* against the [GBIF backbone
 taxonomy](https://www.gbif.org/dataset/d7dddbf4-2cf0-4f39-9b2a-bb099caae36c).
 
-Important is that you have the most recent version of
+It is important that you have the most recent version of
 [inborutils](https://inbo.github.io/inborutils/) installed and
 available:
 


### PR DESCRIPTION
This PR provides an extensive review of tutorial about name match against GBIF Taxonomy Backbone, thus solving issue #134.

This review is needed as the function this tutorial is based on has been improved and slightly changed.

Add a note for Python users as described by @peterdesmet in #134.