### PR TITLE
Add description to tutorial 

### DIFF
--- a/content/tutorials/r_gbif_name_matching/index.Rmd
+++ b/content/tutorials/r_gbif_name_matching/index.Rmd
@@ -1,5 +1,6 @@
 ---
 title: "Match scientific names with the GBIF Backbone Taxonomy"
+description: "How to use inborutils function gbif_species_name_match() to match a list of scientific names against the GBIF backbone taxonomy."
 author: "Dirk Maes, Dimitri Brosens, Damiano Oldoni"
 date: 2019-08-21
 categories: ["r"]

--- a/content/tutorials/r_gbif_name_matching/index.md
+++ b/content/tutorials/r_gbif_name_matching/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Match scientific names with the GBIF Backbone Taxonomy"
+description: "How to use inborutils function gbif_species_name_match() to match a list of scientific names against the GBIF backbone taxonomy."
 author: "Dirk Maes, Dimitri Brosens, Damiano Oldoni"
 date: 2019-08-21
 categories: ["r"]


### PR DESCRIPTION
@peterdesmet noticed that description of tutorial [r_gbif_name_matching](https://inbo.github.io/tutorials/tutorials/r_gbif_name_matching/) is missing.

This PR adds the following text as description: 
> How to use inborutils function gbif_species_name_match() to match a list of scientific names against the GBIF backbone taxonomy.

I added to Rmd and then I knitted it as md.