### PR TITLE
css: colour of hyperlinked code

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -52,6 +52,11 @@
             visibility: visible;
         }
 
+    /* Code in hyperlink inherits colour */
+    a code {
+	color: inherit;
+    }
+
     /* Use white code blocks */
     #content .highlight pre {
         border: 1px solid #bdbdbd;

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -28,6 +28,10 @@
         #content a:hover {
             text-decoration: underline;
         }
+	/* Code in hyperlink inherits colour */
+	#content a code {
+	    color: inherit;
+	}
 
     /* Style descriptions (set in layouts/_default/li.html) */
     #content .item .description {
@@ -51,11 +55,6 @@
         #content h4:hover .anchor {
             visibility: visible;
         }
-
-    /* Code in hyperlink inherits colour */
-    a code {
-	color: inherit;
-    }
 
     /* Use white code blocks */
     #content .highlight pre {


### PR DESCRIPTION
Fixes #201 - seems it was not that difficult.

Result when rendering locally:

![afbeelding](https://user-images.githubusercontent.com/19164640/94016217-224f9880-fdae-11ea-8301-3ee83c4a12de.png)
