### PR TITLE
add protocolhelper package

### DIFF
--- a/content/articles/inbo_software/index.md
+++ b/content/articles/inbo_software/index.md
@@ -33,6 +33,7 @@ The following table gives a **quick overview**:
 | Research stage | Related INBO packages |
 | :------------- | :-------------------- |
 | Study design | [grts](https://github.com/ThierryO/grts)  |
+| Study design | [protocolhelper](https://github.com/inbo/protocolhelper)  |
 | Retrieve data: general | [inbodb](https://inbo.github.io/inbodb) |
 | Retrieve data: environmental | [wateRinfo](https://ropensci.github.io/wateRinfo/), [pydov](https://pydov.readthedocs.io/), [watina](https://inbo.github.io/watina) |
 | Retrieve data: biological | [pyinaturalist](https://github.com/inbo/pyinaturalist), [uvabits](https://inbo.github.io/uvabits/), [etn](https://inbo.github.io/etn/), [n2khab](https://inbo.github.io/n2khab), [forrescalc](https://inbo.github.io/forrescalc/) |
@@ -49,6 +50,10 @@ The following table gives a **quick overview**:
   - **R package [grts](https://github.com/ThierryO/grts)**: draw a
     sample from a sampling frame with the Generalized Random
     Tessellation Stratified (GRTS) sampling strategy.
+  - **R package [protocolhelper](https://github.com/inbo/protocolhelper)**:
+  provides templates for protocols and helper functions to start developing a 
+  new protocol or move an existing protocol to the 
+  [INBO protocols repository](https://github.com/inbo/protocols)
 
 ## Retrieve data
 

--- a/content/articles/inbo_software/index.md
+++ b/content/articles/inbo_software/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Software by INBO: packages for environmentalists and ecologists!"
-date: 2020-01-30
+date: 2020-12-03
 categories: ["development", "r", "statistics", "databases"]
 tags: ["open science", "packages", "r", "python"]
 output: 

--- a/content/articles/inbo_software/index.md
+++ b/content/articles/inbo_software/index.md
@@ -30,8 +30,7 @@ The following table gives a **quick overview**:
 
 | Research stage | Related INBO packages |
 | :------------- | :-------------------- |
-| Study design | [grts](https://github.com/ThierryO/grts)  |
-| Study design | [protocolhelper](https://github.com/inbo/protocolhelper)  |
+| Study design | [grts](https://github.com/ThierryO/grts), [protocolhelper](https://github.com/inbo/protocolhelper)  |
 | Retrieve data: general | [inbodb](https://inbo.github.io/inbodb) |
 | Retrieve data: environmental | [wateRinfo](https://ropensci.github.io/wateRinfo/), [pydov](https://pydov.readthedocs.io/), [watina](https://inbo.github.io/watina) |
 | Retrieve data: biological | [pyinaturalist](https://github.com/inbo/pyinaturalist), [uvabits](https://inbo.github.io/uvabits/), [etn](https://inbo.github.io/etn/), [n2khab](https://inbo.github.io/n2khab), [forrescalc](https://inbo.github.io/forrescalc/) |

--- a/content/articles/inbo_software/index.md
+++ b/content/articles/inbo_software/index.md
@@ -1,8 +1,6 @@
 ---
 title: "Software by INBO: packages for environmentalists and ecologists!"
 date: 2020-01-30
-csl: download.file("https://github.com/citation-style-language/styles/raw/master/research-institute-for-nature-and-forest.csl", tempfile())
-bibliography: ../reproducible_research.bib
 categories: ["development", "r", "statistics", "databases"]
 tags: ["open science", "packages", "r", "python"]
 output: 


### PR DESCRIPTION
This PR addresses #183 partly (action still needed from other package maintainers).

Note, when I tried to preview the md file, the following error appeared:

````
"C:/Users/HANS_V~1/AppData/Local/Pandoc/pandoc" +RTS -K512m -RTS index.utf8.md --to gfm --from markdown+autolink_bare_uris+tex_math_single_backslash --output index.md --standalone --filter "C:/Users/HANS_V~1/AppData/Local/Pandoc/pandoc-citeproc.exe" 
pandoc-citeproc.exe: PandocResourceNotFound "download.file(\8220https://github.com/citation-style-language/styles/raw/master/research-institute-for-nature-and-forest.csl\8221, tempfile())"
Error running filter C:/Users/HANS_V~1/AppData/Local/Pandoc/pandoc-citeproc.exe:
Filter returned error status 1
Error: pandoc document conversion failed with error 83
Execution halted
````

but I don't see any problems or changes I made in the md file that might cause this error. So I think it should be OK.
