### PR TITLE
[git-conflict] fix: continue rebase command

### DIFF
--- a/content/tutorials/git_conflict/index.md
+++ b/content/tutorials/git_conflict/index.md
@@ -47,7 +47,7 @@ Continue with your rebase
 git rebase --continue
 ```
 
-If more troubles occur, fix them, add them, and do a ```git rebase continue```
+If more troubles occur, fix them, add them, and do a ```git rebase --continue```
 
 Force push your branch to the server. (force because you changed the commit)
 


### PR DESCRIPTION
This is a minor correction, you've forgot to add `--` in front of `continue` option.