### PR TITLE
Rprofile.site: name CRAN repo as 'CRAN', not 'RStudio'

### DIFF
--- a/content/installation/administrator/admin_install_r/Rprofile.site
+++ b/content/installation/administrator/admin_install_r/Rprofile.site
@@ -16,7 +16,7 @@ options(
     Roxygen = "list(markdown = TRUE)"
   ),
   repos = c(
-    RStudio = "https://cloud.r-project.org/",
+    CRAN = "https://cloud.r-project.org/",
     INLA = "https://inla.r-inla-download.org/R/stable"
   ),
   install.packages.check.source = "no",


### PR DESCRIPTION
Suggesting this in order to:

- recognize the fact that https://cloud.r-project.org/ will just refer CRAN - even though it is a service currently sponsored by RStudio (auto-redirection to nearest CRAN-mirror)
- prevent `renv` from also using the name 'RStudio' for this repo
- prevent `renv` from updating all package's repository names in `renv.lock` from 'CRAN' to 'RStudio', which it now seems to want (maybe this was a project-specific side-effect of `snapshot.type: all`)
- prevent confusion between https://cloud.r-project.org/ and RStudio's own CRAN mirror https://cran.rstudio.com/
- prevent confusion between CRAN and RSPM (online RStudio Package Manager; see https://packagemanager.rstudio.com/client/#/repos/1/overview), which can also be used as a repo and which lags a few days behind CRAN