### PR TITLE
Update homepage: link to Readme for more background

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -32,6 +32,8 @@ Great news! By sharing information, we can effectively help each other. Moreover
 
 Check the [_create tutorial_]({{< relref "/create_tutorial/index.md" >}}) page for more information on how to contribute to this website!
 
+Further background can be found in the [Readme](https://github.com/inbo/tutorials/blob/master/README.md) of the code repository.
+
 ## Questions?
 
 If you have any questions, do not hesitate to contact the website maintainers (main contributors listed [here](https://github.com/inbo/tutorials/graphs/contributors)), provide a [new issue](https://github.com/inbo/tutorials/issues/new) if you already have a Github account or just ask the [IT helpdesk](mailto:ict.helpdesk@inbo.be) for more information. 


### PR DESCRIPTION
## Description

As [suggested](https://github.com/inbo/tutorials/issues/251#issuecomment-836605470) by @ElsLommelen: refer to Readme. This is a first step to connect different places with information for contributing.

See further in https://github.com/inbo/tutorials/issues/252 with relation to the automatic website built.

## Task list

- [X] My tutorial or article is placed in a subfolder of `tutorials/content`
- [X] The filename of my tutorial or article is `index.md`. In case of an Rmarkdown tutorial I have knitted my `index.Rmd` to `index.md` (both files are pushed to the repo). 
- [X] I have included `tags` in the YAML header (see the tags listed in the [tutorials website side bar](https://inbo.github.io/tutorials/) for tags that have been used before)
- [X] I have added `categories` to the YAML header and my category tags are from the [list of category tags](https://github.com/inbo/tutorials/blob/master/static/list_of_categories)

<!--If you like to preview the website version of your (draft) tutorial, please read https://github.com/inbo/tutorials/blob/master/.github/workflows/REVIEWING.md-->
