### PR TITLE
Tutorial on updating R packages and R in a project renv environment

### DIFF
--- a/content/tutorials/r_renv_update/index.md
+++ b/content/tutorials/r_renv_update/index.md
@@ -9,23 +9,23 @@ tags: ["renv", "r", "packages"]
 
 ## What is `renv`?
 
-`renv` is an R package that provides tools to save the version of R and all packages used in a particular directory (e.g. an RStudio project directory), and to reproduce (recreate) this environment on another (or your future) system.
+`renv` is an R package that provides tools to save the version of R and all packages used in a particular directory with R code (e.g. an RStudio project directory), and to reproduce (recreate) this environment on another (or your future) system.
 Because software versions can have important effects on the results of your work, it is important to be able to reproduce versions.
 
-For basic advice on how to setup and use `renv`, see <https://rstudio.github.io/renv>.
+For general advice on `renv` setup and usage, see <https://rstudio.github.io/renv>.
 The functions you mostly need, are `renv::init()`, `renv::snapshot()`, `renv::status()`, `renv::restore()` (always put `renv::restore()` in the beginning of your R code).
 
 ## Aim
 
 This tutorial addresses the specific aspect of how to update R and packages in an `renv` environment and store that information in the obligate `renv.lock` file.
-It is typically the case while elaborating a project, where you wish to use the latest available packages and R version.
+It is typically needed while elaborating a project, because you wish to use the latest available packages and R version.
 
 While it is not the only possible way, the general approach in this tutorial is:
 
 1. Update all installed packages in the default user R library of your system, i.e. outside an `renv` environment.
 See [this](../../installation/user/user_install_r) tutorial.
 In this way these package versions will need to be downloaded and installed only once.
-You may also want to update packages from other sources, such as GitHub: use `remotes::install_github()` to install the version you want.
+You may also want to update packages from other sources, such as GitHub: use `remotes::install_github()`.
 1. Update packages in a project `renv` environment, and store the new state in `renv.lock`.
 
 ## Procedure

--- a/content/tutorials/r_renv_update/index.md
+++ b/content/tutorials/r_renv_update/index.md
@@ -48,9 +48,8 @@ renv::update() # updates packages from CRAN and GitHub, within the project
 renv::snapshot() # inspect the message before confirming to overwrite renv.lock
 ```
 
-Notes:
+Note:
 
-- `renv` typically already performs an automatic upgrade (`renv::upgrade()`) upon launching the `renv` environment (reported on launch).
 - To update packages in the `renv` environment, `renv` will take package copies of your user R library if the required versions are available there.
 Note that the copies are stored in a [global `renv` package cache](https://rstudio.github.io/renv/articles/renv.html#cache-1), i.e. a central directory where `renv` stores packages versions for all projects where it is used, for each R `x.y` version, on an as-needed basis.
 The project environment itself is based on symlinks to the particular package versions in the cache.
@@ -70,7 +69,7 @@ Below procedure assumes:
 - you have now started the project's R session with the new R version (with `renv` activated).
 
 ```r
-renv::upgrade() # upgrades renv. See note in previous section.
+renv::upgrade() # upgrades renv, if new version is available
 renv::hydrate(update = "all") # populates the renv cache with copies of up to 
                               # date package versions, needed by the project
   # renv::update() should have no effect now, but running it as well won't harm 

--- a/content/tutorials/r_renv_update/index.md
+++ b/content/tutorials/r_renv_update/index.md
@@ -49,6 +49,8 @@ Notes:
 Note that the copies are stored in a [global `renv` package cache](https://rstudio.github.io/renv/articles/renv.html#cache-1), i.e. a central directory where `renv` stores packages versions for all projects where it is used, for each R `x.y` version, on an as-needed basis.
 The project environment itself is based on symlinks to the particular package versions in the cache.
 
+If you use version control, then don't forget to effectively commit the changed `renv.lock` file.
+
 ### Updating R and packages
 
 This procedure is relevant to the `x.y` upgrades, not to the patches.

--- a/content/tutorials/r_renv_update/index.md
+++ b/content/tutorials/r_renv_update/index.md
@@ -2,7 +2,7 @@
 title: "Updating the renv environment of an R project"
 description: "Updating R and packages in an renv environment"
 authors: [florisvdh]
-date: 2021-09-06
+date: 2021-06-09
 categories: ["r"]
 tags: ["renv", "r", "packages"]
 ---

--- a/content/tutorials/r_renv_update/index.md
+++ b/content/tutorials/r_renv_update/index.md
@@ -20,7 +20,7 @@ The functions you mostly need, are `renv::init()`, `renv::snapshot()`, `renv::st
 When using git version control, you should commit all new untracked files created by `renv::init()`.
 The most important file is `renv.lock`, which defines R and package versions of the project.
 
-## Aim
+## Aim of this tutorial
 
 This tutorial addresses the specific aspect of how to update R and packages in an `renv` environment and store that information in `renv.lock`.
 It is typically needed while elaborating a project, because you wish to use the latest available packages and R version.

--- a/content/tutorials/r_renv_update/index.md
+++ b/content/tutorials/r_renv_update/index.md
@@ -45,7 +45,7 @@ renv::snapshot() # inspect the message before confirming to overwrite renv.lock
 Notes:
 
 - `renv` typically already performs an automatic upgrade (`renv::upgrade()`) upon launching the `renv` environment (reported on launch).
-- To update packages in the `renv` environment, `renv` will take package copies of your user R library if the right versions are available there.
+- To update packages in the `renv` environment, `renv` will take package copies of your user R library if the required versions are available there.
 Note that the copies are stored in a [global `renv` package cache](https://rstudio.github.io/renv/articles/renv.html#cache-1), i.e. a central directory where `renv` stores packages versions for all projects where it is used, for each R `x.y` version, on an as-needed basis.
 The project environment itself is based on symlinks to the particular package versions in the cache.
 
@@ -55,7 +55,7 @@ If you use version control, then don't forget to effectively commit the changed 
 
 This procedure is relevant to the `x.y` upgrades, not to the patches.
 That is, when `x` or `y` change in R version `x.y.z`.
-When only `z` has changed, previous procedure still applies. 
+When only `z` has changed (i.e. a 'patch'), previous procedure still applies. 
 
 Below procedure assumes:
 
@@ -73,4 +73,3 @@ renv::snapshot() # inspect the message before confirming to overwrite renv.lock
 ```
 
 If you use version control, then don't forget to effectively commit the changed `renv.lock` file.
-

--- a/content/tutorials/r_renv_update/index.md
+++ b/content/tutorials/r_renv_update/index.md
@@ -1,0 +1,74 @@
+---
+title: "Updating the renv environment of an R project"
+description: "Updating R and packages in an renv environment"
+authors: [florisvdh]
+date: 2021-09-06
+categories: ["r"]
+tags: ["renv", "r", "packages"]
+---
+
+## What is `renv`?
+
+`renv` is an R package that provides tools to save the version of R and all packages used in a particular directory (e.g. an RStudio project directory), and to reproduce (recreate) this environment on another (or your future) system.
+Because software versions can have important effects on the results of your work, it is important to be able to reproduce versions.
+
+For basic advice on how to setup and use `renv`, see <https://rstudio.github.io/renv>.
+The functions you mostly need, are `renv::init()`, `renv::snapshot()`, `renv::status()`, `renv::restore()` (always put `renv::restore()` in the beginning of your R code).
+
+## Aim
+
+This tutorial addresses the specific aspect of how to update R and packages in an `renv` environment and store that information in the obligate `renv.lock` file.
+It is typically the case while elaborating a project, where you wish to use the latest available packages and R version.
+
+While it is not the only possible way, the general approach in this tutorial is:
+
+1. Update all installed packages in the default user R library of your system, i.e. outside an `renv` environment.
+See [this](../../installation/user/user_install_r) tutorial.
+In this way these package versions will need to be downloaded and installed only once.
+You may also want to update packages from other sources, such as GitHub: use `remotes::install_github()` to install the version you want.
+1. Update packages in a project `renv` environment, and store the new state in `renv.lock`.
+
+## Procedure
+
+**We assume you already applied step 1 above!**
+
+### Only updating packages (keeping same R version)
+
+Within the project's R session (with `renv` activated):
+
+```r
+renv::upgrade() # upgrades renv, if new version is available
+renv::update() # updates packages from CRAN and GitHub, within the project
+renv::snapshot() # inspect the message before confirming to overwrite renv.lock
+```
+
+Notes:
+
+- `renv` typically already performs an automatic upgrade (`renv::upgrade()`) upon launching the `renv` environment (reported on launch).
+- To update packages in the `renv` environment, `renv` will take package copies of your user R library if the right versions are available there.
+Note that the copies are stored in a [global `renv` package cache](https://rstudio.github.io/renv/articles/renv.html#cache-1), i.e. a central directory where `renv` stores packages versions for all projects where it is used, for each R `x.y` version, on an as-needed basis.
+The project environment itself is based on symlinks to the particular package versions in the cache.
+
+### Updating R and packages
+
+This procedure is relevant to the `x.y` upgrades, not to the patches.
+That is, when `x` or `y` change in R version `x.y.z`.
+When only `z` has changed, previous procedure still applies. 
+
+Below procedure assumes:
+
+- you already installed the new R version on your system;
+- you already updated your R packages in the default user R library of your system;
+- you have now started the project's R session with the new R version (with `renv` activated).
+
+```r
+renv::upgrade() # upgrades renv. See note in previous section.
+renv::hydrate(update = "all") # populates the renv cache with copies of up to 
+                              # date package versions, needed by the project
+  # renv::update() should have no effect now, but running it as well won't harm 
+  # to check that all packages are indeed up to date
+renv::snapshot() # inspect the message before confirming to overwrite renv.lock
+```
+
+If you use version control, then don't forget to effectively commit the changed `renv.lock` file.
+

--- a/content/tutorials/r_renv_update/index.md
+++ b/content/tutorials/r_renv_update/index.md
@@ -25,17 +25,18 @@ The most important file is `renv.lock`, which defines R and package versions of 
 This tutorial addresses the specific aspect of how to update R and packages in an `renv` environment and store that information in `renv.lock`.
 It is typically needed while elaborating a project, because you wish to use the latest available packages and R version.
 
-While it is not the only possible way, the general approach in this tutorial is:
+## Procedure
+
+Our recommended approach is:
 
 1. Update all installed packages in the default user R library of your system, i.e. outside an `renv` environment.
 See [this](../../installation/user/user_install_r) tutorial.
 In this way these package versions will need to be downloaded and installed only once.
 You may also want to update packages from other sources, such as GitHub: use `remotes::install_github()`.
-1. Update packages in a project `renv` environment, and store the new state in `renv.lock`.
+1. Update packages, and possibly R, in a project `renv` environment, and store the new state in `renv.lock`.
 
-## Procedure
-
-**We assume you already applied step 1 above!**
+**To apply step 2, choose the applicable situation below.**
+**We assume you already applied step 1!**
 
 ### Only updating packages (keeping same R version)
 

--- a/content/tutorials/r_renv_update/index.md
+++ b/content/tutorials/r_renv_update/index.md
@@ -12,12 +12,17 @@ tags: ["renv", "r", "packages"]
 `renv` is an R package that provides tools to save the version of R and all packages used in a particular directory with R code (e.g. an RStudio project directory), and to reproduce (recreate) this environment on another (or your future) system.
 Because software versions can have important effects on the results of your work, it is important to be able to reproduce versions.
 
+## Start using `renv`
+
 For general advice on `renv` setup and usage, see <https://rstudio.github.io/renv>.
 The functions you mostly need, are `renv::init()`, `renv::snapshot()`, `renv::status()`, `renv::restore()` (always put `renv::restore()` in the beginning of your R code).
 
+When using git version control, you should commit all new untracked files created by `renv::init()`.
+The most important file is `renv.lock`, which defines R and package versions of the project.
+
 ## Aim
 
-This tutorial addresses the specific aspect of how to update R and packages in an `renv` environment and store that information in the obligate `renv.lock` file.
+This tutorial addresses the specific aspect of how to update R and packages in an `renv` environment and store that information in `renv.lock`.
 It is typically needed while elaborating a project, because you wish to use the latest available packages and R version.
 
 While it is not the only possible way, the general approach in this tutorial is:


### PR DESCRIPTION
## Description

See title. I applied the second part of the tutorial (R upgrade to 4.1) in a `renv` project yesterday, so I thought it would be useful to share.

## Task list

- [X] My tutorial or article is placed in a subfolder of `tutorials/content`
- [X] The filename of my tutorial or article is `index.md`. In case of an Rmarkdown tutorial I have knitted my `index.Rmd` to `index.md` (both files are pushed to the repo). 
- [X] I have included `tags` in the YAML header (see the tags listed in the [tutorials website side bar](https://inbo.github.io/tutorials/) for tags that have been used before)
- [X] I have added `categories` to the YAML header and my category tags are from the [list of category tags](https://github.com/inbo/tutorials/blob/master/static/list_of_categories)




