### PR TITLE
PR template: put task list at the end

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,21 +4,6 @@
 Thank you for contributing to the INBO tutorials repository.
 -->
 
-## Task list
-
-<!--see https://docs.github.com/en/github/managing-your-work-on-github/about-task-lists
-for an explanation on how to use task lists-->
-
-Please check if the following steps are OK:
-
-- [ ] My tutorial or article is placed in a subfolder of `tutorials/content`
-- [ ] The filename of my tutorial or article is `index.md`. In case of an Rmarkdown tutorial I have knitted my `index.Rmd` to `index.md` (both files are pushed to the repo). 
-- [ ] I have included `tags` in the YAML header (see the tags listed in the [tutorials website side bar](https://inbo.github.io/tutorials/) for tags that have been used before)
-- [ ] I have added `categories` to the YAML header and my category tags are from the [list of category tags](https://github.com/inbo/tutorials/blob/master/static/list_of_categories)
-
-
-
-
 ## Description
 <!--- Briefly describe the tutorial or article that you want to contribute
 or update-->
@@ -33,3 +18,17 @@ it like "#4" -->
 
 
 <!--If you like to preview the website version of your (draft) tutorial, please read https://github.com/inbo/tutorials/blob/master/.github/workflows/REVIEWING.md-->
+
+## Task list
+
+<!--see https://docs.github.com/en/github/managing-your-work-on-github/about-task-lists
+for an explanation on how to use task lists-->
+
+<!-- Please check if the following steps are OK:-->
+
+- [ ] My tutorial or article is placed in a subfolder of `tutorials/content`
+- [ ] The filename of my tutorial or article is `index.md`. In case of an Rmarkdown tutorial I have knitted my `index.Rmd` to `index.md` (both files are pushed to the repo). 
+- [ ] I have included `tags` in the YAML header (see the tags listed in the [tutorials website side bar](https://inbo.github.io/tutorials/) for tags that have been used before)
+- [ ] I have added `categories` to the YAML header and my category tags are from the [list of category tags](https://github.com/inbo/tutorials/blob/master/static/list_of_categories)
+
+


### PR DESCRIPTION
Since the task list is shown in the PR, it seems odd to put this mere administrative list above the description of what the PR is about. Have moved it to the end, as well as outcommented the line 'Please check if the following steps are OK:'

Compare with below _original_, rendered template:

<!--- indicate the Title for this pull request (PR) above -->

<!--
Thank you for contributing to the INBO tutorials repository.
-->

## Task list

<!--see https://docs.github.com/en/github/managing-your-work-on-github/about-task-lists
for an explanation on how to use task lists-->

Please check if the following steps are OK:

- [ ] My tutorial or article is placed in a subfolder of `tutorials/content`
- [ ] The filename of my tutorial or article is `index.md`. In case of an Rmarkdown tutorial I have knitted my `index.Rmd` to `index.md` (both files are pushed to the repo). 
- [ ] I have included `tags` in the YAML header (see the tags listed in the [tutorials website side bar](https://inbo.github.io/tutorials/) for tags that have been used before)
- [ ] I have added `categories` to the YAML header and my category tags are from the [list of category tags](https://github.com/inbo/tutorials/blob/master/static/list_of_categories)




## Description
<!--- Briefly describe the tutorial or article that you want to contribute
or update-->
<!--- You can mention collaborators with "@githubname"-->


## Related Issue
<!--- if this closes an issue make sure to include e.g., "closes #4"
or similar - or if it just relates to an issue make sure to mention
it like "#4" -->
<!--See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword-->


<!--If you like to preview the website version of your (draft) tutorial, please read https://github.com/inbo/tutorials/blob/master/.github/workflows/REVIEWING.md-->
