### PR TITLE
Fix articles ordering (#155)

### DIFF
--- a/content/articles/communicating/index.Rmd
+++ b/content/articles/communicating/index.Rmd
@@ -8,7 +8,6 @@ tags: ["literature", "open science"]
 output: 
     md_document:
         preserve_yaml: true
-weight: 4
 ---
 
 This page lists **selected** literature and online resources. Some are related to existing tutorial pages, while others are not. They are supposed to be of high interest to this site's users.

--- a/content/articles/communicating/index.md
+++ b/content/articles/communicating/index.md
@@ -8,7 +8,6 @@ tags: ["literature", "open science"]
 output: 
     md_document:
         preserve_yaml: true
-weight: 4
 ---
 
 This page lists **selected** literature and online resources. Some are

--- a/content/articles/computing/index.Rmd
+++ b/content/articles/computing/index.Rmd
@@ -9,7 +9,6 @@ output:
     md_document:
         preserve_yaml: true
         variant: gfm
-weight: 2
 ---
 
 This page lists **selected** literature and online resources. Some are related to existing tutorial pages, while others are not. They are supposed to be of high interest to this site's users.

--- a/content/articles/computing/index.md
+++ b/content/articles/computing/index.md
@@ -9,7 +9,6 @@ output:
     md_document:
         preserve_yaml: true
         variant: gfm
-weight: 2
 ---
 
 This page lists **selected** literature and online resources. Some are

--- a/content/articles/inbo_software/index.md
+++ b/content/articles/inbo_software/index.md
@@ -7,7 +7,6 @@ output:
     md_document:
         preserve_yaml: true
         variant: gfm
-weight: 1
 ---
 
 At the Research Institute for Nature and Forest (INBO), we are eager to

--- a/content/articles/open_science/index.Rmd
+++ b/content/articles/open_science/index.Rmd
@@ -8,7 +8,6 @@ tags: ["literature", "open science"]
 output: 
     md_document:
         preserve_yaml: true
-weight: 5
 ---
 
 This page lists **selected** literature and online resources. Some are related to existing tutorial pages, while others are not. They are supposed to be of high interest to this site's users.

--- a/content/articles/open_science/index.md
+++ b/content/articles/open_science/index.md
@@ -8,7 +8,6 @@ tags: ["literature", "open science"]
 output: 
     md_document:
         preserve_yaml: true
-weight: 5
 ---
 
 This page lists **selected** literature and online resources. Some are

--- a/content/articles/skills/index.Rmd
+++ b/content/articles/skills/index.Rmd
@@ -8,7 +8,6 @@ tags: ["literature", "open science"]
 output: 
     md_document:
         preserve_yaml: true
-weight: 3
 ---
 
 This page lists **selected** literature and online resources. Some are related to existing tutorial pages, while others are not. They are supposed to be of high interest to this site's users.

--- a/content/articles/skills/index.md
+++ b/content/articles/skills/index.md
@@ -8,7 +8,6 @@ tags: ["literature", "open science"]
 output: 
     md_document:
         preserve_yaml: true
-weight: 3
 ---
 
 This page lists **selected** literature and online resources. Some are

--- a/content/articles/statistics/index.Rmd
+++ b/content/articles/statistics/index.Rmd
@@ -8,7 +8,6 @@ tags: ["literature", "open science"]
 output: 
     md_document:
         preserve_yaml: true
-weight: 1
 ---
 
 ```{r setup, include = FALSE}

--- a/content/articles/statistics/index.md
+++ b/content/articles/statistics/index.md
@@ -8,7 +8,6 @@ tags: ["literature", "open science"]
 output: 
     md_document:
         preserve_yaml: true
-weight: 1
 ---
 
 -   McElreath (2015): Statistical Rethinking is an introduction to


### PR DESCRIPTION
## Description

fix the articles ordering issue described in #155. It does this very simply by removing the weight associated to each article. In that case, Hugo use the date for ordering. I assume the existing `weight` properties were assigned a bit randomly while authoring (copy-paste from a previous article, then tweaking).

Leaving the weight empty to let the computer sort by date is cleaner, IMHO.