### PR TITLE
Better "improve this page" link. Fix #258

### DIFF
--- a/layouts/partials/entry/meta/edit-page.html
+++ b/layouts/partials/entry/meta/edit-page.html
@@ -10,7 +10,7 @@
             {{ $.Scratch.Set "FilePath" .File.Path }}
         {{ end }}
 
-        {{ with .Site.Params.githublink.GithubContentLink}}
+        {{ with .Site.Params.githublink.GithubEditLink }}
             <a href='{{ . }}{{ $.Scratch.Get "FilePath" }}'> {{- partial "svg/icons" "github" -}} Improve this page</a>
         {{ end }}
 


### PR DESCRIPTION
Fix the "improve this page link" so it goes directly to the `edit` page, just as described in #258.


