### PR TITLE
Drop links to discarded REVIEWING.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,7 @@ it like "#4" -->
 <!--See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword-->
 
 
-<!--If you like to preview the website version of your (draft) tutorial, please read https://github.com/inbo/tutorials/blob/master/.github/workflows/REVIEWING.md-->
+<!--For previewing the website version of your (draft) tutorial, see the instructions further below.-->
 
 ## Task list
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,8 +17,6 @@ it like "#4" -->
 <!--See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword-->
 
 
-<!--For previewing the website version of your (draft) tutorial, see the instructions further below.-->
-
 ## Task list
 
 <!--see https://docs.github.com/en/github/managing-your-work-on-github/about-task-lists

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ New tutorials should go in a new directory in `content/tutorials`. Use plain mar
 ## Reviewing the website in a pull request (before merging)
 
 Thanks to GitHub Actions, an artifact (=zip file) of the rendered website is now automatically created on each pull request.
-Read [REVIEWING.md](.github/workflows/REVIEWING.md) to learn about showing the development website in your browser.
+[Learn more](https://github.com/inbo/tutorials/blob/master/.github/pull_request_template.md#previewing-the-pull-request) about showing the development website of a pull request in your browser.
 
 ## Building the site
 


### PR DESCRIPTION
<!--- indicate the Title for this pull request (PR) above -->

<!--
Thank you for contributing to the INBO tutorials repository.
-->

## Description

Dropped links to discarded `REVIEWING.md`, in `README.md` and PR template. Replaced by appropriate reference to PR template.


## Related Issue

Fixes #292

<!--If you like to preview the website version of your (draft) tutorial, please read https://github.com/inbo/tutorials/blob/master/.github/workflows/REVIEWING.md-->

