### PR TITLE
Add Zenodo vignette from checklist package

### DIFF
--- a/content/tutorials/vignette_checklist_zenodo/index.md
+++ b/content/tutorials/vignette_checklist_zenodo/index.md
@@ -1,0 +1,13 @@
+---
+title: "Setting up the integration between GitHub, Zenodo and ORCID"
+description: "Vignette for the R package checklist."
+authors: [thierryo]
+categories: ["r"]
+tags: ["r", "vignette", "checklist"]
+output: 
+    md_document:
+        preserve_yaml: true
+        variant: markdown_github
+---
+
+See the vignette/tutorial at <https://inbo.github.io/checklist/articles/zenodo.html>


### PR DESCRIPTION
<!--- indicate the Title for this pull request (PR) above -->

<!--
Thank you for contributing to the INBO tutorials repository.
-->

## Description

This adds the vignette that @ThierryO recently created in `checklist`.

@peterdesmet beware I did not yet apply any of the newer approaches, both regarding 📦 and regarding `gfm+footnotes` (PR #285), leaving it to you on choosing where and when to do that.

## Related Issue
<!--- if this closes an issue make sure to include e.g., "closes #4"
or similar - or if it just relates to an issue make sure to mention
it like "#4" -->
<!--See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword-->


## Task list

<!--see https://docs.github.com/en/github/managing-your-work-on-github/about-task-lists
for an explanation on how to use task lists-->

<!-- Please check if the following steps are OK:-->

- [X] My tutorial or article is placed in a subfolder of `tutorials/content`
- [X] The filename of my tutorial or article is `index.md`. In case of an Rmarkdown tutorial I have knitted my `index.Rmd` to `index.md` (both files are pushed to the repo). 
- [X] I have included `tags` in the YAML header (see the tags listed in the [tutorials website side bar](https://inbo.github.io/tutorials/) for tags that have been used before)
- [X] I have added `categories` to the YAML header and my category tags are from the [list of category tags](https://github.com/inbo/tutorials/blob/master/static/list_of_categories)


