### PR TITLE
Hotfix RProfile.site

### DIFF
--- a/content/installation/administrator/admin_install_r/Rprofile.site
+++ b/content/installation/administrator/admin_install_r/Rprofile.site
@@ -29,6 +29,13 @@ if (
       "-win.exe first to install them automatically."
     )
   } else {
+    # remove any existing LOCK file
+    file.remove(
+      list.files(
+        file.path(.libPaths(), "00LOCK"), recursive = TRUE,
+        full.names = TRUE
+      )
+    )
     if (!"remotes" %in% rownames(utils::installed.packages())) {
       message("Installing `remotes`, may take some time")
       utils::install.packages(

--- a/content/installation/administrator/admin_install_r/Rprofile.site
+++ b/content/installation/administrator/admin_install_r/Rprofile.site
@@ -12,58 +12,11 @@ options(
     INLA = "https://inla.r-inla-download.org/R/stable",
     inbo = "https://inbo.r-universe.dev"
   ),
+  pkgType = "binary",
   install.packages.check.source = "no",
-  install.packages.compile.from.source = "never"
+  install.packages.compile.from.source = "never",
+  inbo_required = c("checklist", "fortunes", "remotes", "INBOmd", "INBOtheme")
 )
-if (
-  !all(
-    c("checklist", "fortunes", "remotes") %in%
-    rownames(utils::installed.packages())
-  )
-) {
-  if (Sys.getenv("RSTUDIO") == "1") {
-    warning(
-      "Missing packages. ",
-      "Please close RStudio and run R ",
-      paste(R.Version()[c("major", "minor")], collapse = "."),
-      " first to install them automatically."
-    )
-  } else {
-    if (any(dir.exists(file.path(.libPaths(), "00LOCK")))) {
-      stop(
-        "Please remove the directories below and restart R\n",
-        paste(
-          file.path(.libPaths(), "00LOCK")[
-            dir.exists(file.path(.libPaths(), "00LOCK"))
-          ],
-          collapse = "\n"
-        )
-      )
-    }
-    if (!"remotes" %in% rownames(utils::installed.packages())) {
-      message("Installing `remotes`, may take some time")
-      utils::install.packages(
-        "remotes", dependencies = TRUE
-      )
-    }
-    stopifnot(
-      "Failed to install package `remotes`." =
-      "remotes" %in% rownames(utils::installed.packages())
-    )
-    if (!"checklist" %in% rownames(utils::installed.packages())) {
-      message("Installing `checklist`, may take some time")
-      remotes::install_cran(
-        "checklist", upgrade = "always", dependencies = TRUE
-      )
-    }
-    if (!"fortunes" %in% rownames(utils::installed.packages())) {
-      message("Installing `fortunes`, may take some time")
-      remotes::install_cran(
-        "fortunes", upgrade = "always", dependencies = TRUE
-      )
-    }
-  }
-}
 # display fortune when starting new interactive R session
 if (interactive() && "fortunes" %in% rownames(utils::installed.packages())) {
   tryCatch(
@@ -77,5 +30,28 @@ if (interactive() && "fortunes" %in% rownames(utils::installed.packages())) {
 if ("checklist" %in% rownames(utils::installed.packages())) {
   options(
     lintr.linter_file = system.file("lintr", package = "checklist")
+  )
+}
+
+if (
+  !all(getOption("inbo_required") %in% rownames(utils::installed.packages()))
+) {
+  stop(
+    c(
+      "\n",
+      rep("^", getOption("width")),
+      "\nThis R installation lacks some required INBO packages.",
+      "\nPlease install them using the code below:\n",
+      "\ninstall.packages(c(",
+      paste0(
+        "\"",
+        getOption("inbo_required")[
+          !getOption("inbo_required") %in% rownames(utils::installed.packages())
+        ],
+        "\"", collapse = ", "
+      ),
+      "))\n\n",
+      rep("^", getOption("width"))
+    )
   )
 }

--- a/content/installation/administrator/admin_install_r/Rprofile.site
+++ b/content/installation/administrator/admin_install_r/Rprofile.site
@@ -29,13 +29,17 @@ if (
       "-win.exe first to install them automatically."
     )
   } else {
-    # remove any existing LOCK file
-    file.remove(
-      list.files(
-        file.path(.libPaths(), "00LOCK"), recursive = TRUE,
-        full.names = TRUE
+    if (any(dir.exists(file.path(.libPaths(), "00LOCK")))) {
+      stop(
+        "Please remove the directories below and restart R\n",
+        paste(
+          file.path(.libPaths(), "00LOCK")[
+            dir.exists(file.path(.libPaths(), "00LOCK"))
+          ],
+          collapse = "\n"
+        )
       )
-    )
+    }
     if (!"remotes" %in% rownames(utils::installed.packages())) {
       message("Installing `remotes`, may take some time")
       utils::install.packages(

--- a/content/installation/administrator/admin_install_r/Rprofile.site
+++ b/content/installation/administrator/admin_install_r/Rprofile.site
@@ -39,7 +39,7 @@ if (
     if (!"remotes" %in% rownames(utils::installed.packages())) {
       message("Installing `remotes`, may take some time")
       utils::install.packages(
-        "remotes", repos = "https://cloud.r-project.org/", dependencies = TRUE
+        "remotes", dependencies = TRUE
       )
     }
     stopifnot(
@@ -49,15 +49,13 @@ if (
     if (!"checklist" %in% rownames(utils::installed.packages())) {
       message("Installing `checklist`, may take some time")
       remotes::install_cran(
-        "checklist", repos = "https://inbo.r-universe.dev", upgrade = "always",
-        dependencies = TRUE
+        "checklist", upgrade = "always", dependencies = TRUE
       )
     }
     if (!"fortunes" %in% rownames(utils::installed.packages())) {
       message("Installing `fortunes`, may take some time")
       remotes::install_cran(
-        "fortunes", repos = "https://cloud.r-project.org/", upgrade = "always",
-        dependencies = TRUE
+        "fortunes", upgrade = "always", dependencies = TRUE
       )
     }
   }

--- a/content/installation/administrator/admin_install_r/Rprofile.site
+++ b/content/installation/administrator/admin_install_r/Rprofile.site
@@ -24,9 +24,9 @@ if (
   if (Sys.getenv("RSTUDIO") == "1") {
     warning(
       "Missing packages. ",
-      "Please close RStudio and run R-",
+      "Please close RStudio and run R ",
       paste(R.Version()[c("major", "minor")], collapse = "."),
-      "-win.exe first to install them automatically."
+      " first to install them automatically."
     )
   } else {
     if (any(dir.exists(file.path(.libPaths(), "00LOCK")))) {

--- a/content/installation/administrator/admin_install_r/Rprofile.site
+++ b/content/installation/administrator/admin_install_r/Rprofile.site
@@ -7,7 +7,6 @@ options(
   xpinch = 300,
   ypinch = 300,
   yaml.eval.expr = TRUE,
-  lintr.linter_file = system.file("lintr", package = "checklist"),
   repos = c(
     CRAN = "https://cloud.r-project.org/",
     INLA = "https://inla.r-inla-download.org/R/stable",
@@ -16,17 +15,21 @@ options(
   install.packages.check.source = "no",
   install.packages.compile.from.source = "never"
 )
-if (!"checklist" %in% rownames(utils::installed.packages())) {
-  utils::install.packages("checklist")
+if (!"remotes" %in% rownames(utils::installed.packages())) {
+  message("Installing remotes, may take some time")
+  utils::install.packages(
+    "remotes", repos = "https://cloud.r-project.org/", dependencies = TRUE
+  )
 }
-options(
-  lintr.linter_file = system.file("lintr", package = "checklist")
-)
 
 # display fortune when starting new interactive R session
 if (interactive()) {
   if (!"fortunes" %in% rownames(utils::installed.packages())) {
-    utils::install.packages("fortunes")
+    message("Installing fortunes, may take some time")
+    remotes::install_cran(
+      "fortunes", repos = "https://cloud.r-project.org/", upgrade = "always",
+      dependencies = TRUE
+    )
   }
   tryCatch(
     print(fortunes::fortune()),
@@ -35,3 +38,14 @@ if (interactive()) {
     }
   )
 }
+
+if (!"checklist" %in% rownames(utils::installed.packages())) {
+  message("Installing `checklist`, may take some time.")
+  remotes::install_cran(
+    "checklist", repos = "https://inbo.r-universe.dev", upgrade = "always",
+    dependencies = TRUE
+  )
+}
+options(
+  lintr.linter_file = system.file("lintr", package = "checklist")
+)

--- a/content/installation/administrator/admin_install_r/Rprofile.site
+++ b/content/installation/administrator/admin_install_r/Rprofile.site
@@ -15,22 +15,48 @@ options(
   install.packages.check.source = "no",
   install.packages.compile.from.source = "never"
 )
-if (!"remotes" %in% rownames(utils::installed.packages())) {
-  message("Installing remotes, may take some time")
-  utils::install.packages(
-    "remotes", repos = "https://cloud.r-project.org/", dependencies = TRUE
+if (
+  !all(
+    c("checklist", "fortunes", "remotes") %in%
+    rownames(utils::installed.packages())
   )
-}
-
-# display fortune when starting new interactive R session
-if (interactive()) {
-  if (!"fortunes" %in% rownames(utils::installed.packages())) {
-    message("Installing fortunes, may take some time")
-    remotes::install_cran(
-      "fortunes", repos = "https://cloud.r-project.org/", upgrade = "always",
-      dependencies = TRUE
+) {
+  if (Sys.getenv("RSTUDIO") == "1") {
+    warning(
+      "Missing packages. ",
+      "Please close RStudio and run R-",
+      paste(R.Version()[c("major", "minor")], collapse = "."),
+      "-win.exe first to install them automatically."
     )
+  } else {
+    if (!"remotes" %in% rownames(utils::installed.packages())) {
+      message("Installing `remotes`, may take some time")
+      utils::install.packages(
+        "remotes", repos = "https://cloud.r-project.org/", dependencies = TRUE
+      )
+    }
+    stopifnot(
+      "Failed to install package `remotes`." =
+      "remotes" %in% rownames(utils::installed.packages())
+    )
+    if (!"checklist" %in% rownames(utils::installed.packages())) {
+      message("Installing `checklist`, may take some time")
+      remotes::install_cran(
+        "checklist", repos = "https://inbo.r-universe.dev", upgrade = "always",
+        dependencies = TRUE
+      )
+    }
+    if (!"fortunes" %in% rownames(utils::installed.packages())) {
+      message("Installing `fortunes`, may take some time")
+      remotes::install_cran(
+        "fortunes", repos = "https://cloud.r-project.org/", upgrade = "always",
+        dependencies = TRUE
+      )
+    }
   }
+}
+# display fortune when starting new interactive R session
+if (interactive() && "fortunes" %in% rownames(utils::installed.packages())) {
   tryCatch(
     print(fortunes::fortune()),
     error = function(e) {
@@ -39,13 +65,8 @@ if (interactive()) {
   )
 }
 
-if (!"checklist" %in% rownames(utils::installed.packages())) {
-  message("Installing `checklist`, may take some time.")
-  remotes::install_cran(
-    "checklist", repos = "https://inbo.r-universe.dev", upgrade = "always",
-    dependencies = TRUE
+if ("checklist" %in% rownames(utils::installed.packages())) {
+  options(
+    lintr.linter_file = system.file("lintr", package = "checklist")
   )
 }
-options(
-  lintr.linter_file = system.file("lintr", package = "checklist")
-)

--- a/content/installation/administrator/admin_install_r/index.md
+++ b/content/installation/administrator/admin_install_r/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Install R"
 description: "Instruction for the installation of R (in Dutch)"
-date: "2022-05-18"
+date: "2022-05-19"
 authors: [thierryo]
 categories: ["installation"]
 tags: ["r", "installation"]
@@ -104,58 +104,11 @@ options(
     INLA = "https://inla.r-inla-download.org/R/stable",
     inbo = "https://inbo.r-universe.dev"
   ),
+  pkgType = "binary",
   install.packages.check.source = "no",
-  install.packages.compile.from.source = "never"
+  install.packages.compile.from.source = "never",
+  inbo_required = c("checklist", "fortunes", "remotes", "INBOmd", "INBOtheme")
 )
-if (
-  !all(
-    c("checklist", "fortunes", "remotes") %in%
-    rownames(utils::installed.packages())
-  )
-) {
-  if (Sys.getenv("RSTUDIO") == "1") {
-    warning(
-      "Missing packages. ",
-      "Please close RStudio and run R ",
-      paste(R.Version()[c("major", "minor")], collapse = "."),
-      " first to install them automatically."
-    )
-  } else {
-    if (any(dir.exists(file.path(.libPaths(), "00LOCK")))) {
-      stop(
-        "Please remove the directories below and restart R\n",
-        paste(
-          file.path(.libPaths(), "00LOCK")[
-            dir.exists(file.path(.libPaths(), "00LOCK"))
-          ],
-          collapse = "\n"
-        )
-      )
-    }
-    if (!"remotes" %in% rownames(utils::installed.packages())) {
-      message("Installing `remotes`, may take some time")
-      utils::install.packages(
-        "remotes", dependencies = TRUE
-      )
-    }
-    stopifnot(
-      "Failed to install package `remotes`." =
-      "remotes" %in% rownames(utils::installed.packages())
-    )
-    if (!"checklist" %in% rownames(utils::installed.packages())) {
-      message("Installing `checklist`, may take some time")
-      remotes::install_cran(
-        "checklist", upgrade = "always", dependencies = TRUE
-      )
-    }
-    if (!"fortunes" %in% rownames(utils::installed.packages())) {
-      message("Installing `fortunes`, may take some time")
-      remotes::install_cran(
-        "fortunes", upgrade = "always", dependencies = TRUE
-      )
-    }
-  }
-}
 # display fortune when starting new interactive R session
 if (interactive() && "fortunes" %in% rownames(utils::installed.packages())) {
   tryCatch(
@@ -169,6 +122,29 @@ if (interactive() && "fortunes" %in% rownames(utils::installed.packages())) {
 if ("checklist" %in% rownames(utils::installed.packages())) {
   options(
     lintr.linter_file = system.file("lintr", package = "checklist")
+  )
+}
+
+if (
+  !all(getOption("inbo_required") %in% rownames(utils::installed.packages()))
+) {
+  stop(
+    c(
+      "\n",
+      rep("^", getOption("width")),
+      "\nThis R installation lacks some required INBO packages.",
+      "\nPlease install them using the code below:\n",
+      "\ninstall.packages(c(",
+      paste0(
+        "\"",
+        getOption("inbo_required")[
+          !getOption("inbo_required") %in% rownames(utils::installed.packages())
+        ],
+        "\"", collapse = ", "
+      ),
+      "))\n\n",
+      rep("^", getOption("width"))
+    )
   )
 }
 ```

--- a/content/installation/administrator/admin_install_r/index.md
+++ b/content/installation/administrator/admin_install_r/index.md
@@ -116,22 +116,26 @@ if (
   if (Sys.getenv("RSTUDIO") == "1") {
     warning(
       "Missing packages. ",
-      "Please close RStudio and run R-",
+      "Please close RStudio and run R ",
       paste(R.Version()[c("major", "minor")], collapse = "."),
-      "-win.exe first to install them automatically."
+      " first to install them automatically."
     )
   } else {
-    # remove any existing LOCK file
-    file.remove(
-      list.files(
-        file.path(.libPaths(), "00LOCK"), recursive = TRUE,
-        full.names = TRUE
+    if (any(dir.exists(file.path(.libPaths(), "00LOCK")))) {
+      stop(
+        "Please remove the directories below and restart R\n",
+        paste(
+          file.path(.libPaths(), "00LOCK")[
+            dir.exists(file.path(.libPaths(), "00LOCK"))
+          ],
+          collapse = "\n"
+        )
       )
-    )
+    }
     if (!"remotes" %in% rownames(utils::installed.packages())) {
       message("Installing `remotes`, may take some time")
       utils::install.packages(
-        "remotes", repos = "https://cloud.r-project.org/", dependencies = TRUE
+        "remotes", dependencies = TRUE
       )
     }
     stopifnot(
@@ -141,15 +145,13 @@ if (
     if (!"checklist" %in% rownames(utils::installed.packages())) {
       message("Installing `checklist`, may take some time")
       remotes::install_cran(
-        "checklist", repos = "https://inbo.r-universe.dev", upgrade = "always",
-        dependencies = TRUE
+        "checklist", upgrade = "always", dependencies = TRUE
       )
     }
     if (!"fortunes" %in% rownames(utils::installed.packages())) {
       message("Installing `fortunes`, may take some time")
       remotes::install_cran(
-        "fortunes", repos = "https://cloud.r-project.org/", upgrade = "always",
-        dependencies = TRUE
+        "fortunes", upgrade = "always", dependencies = TRUE
       )
     }
   }


### PR DESCRIPTION
Solving some remaining issues with the `Rprofile.site`.

- don't install packages when running RStudio but display a warning instead.
- use `remotes::install_cran()` so we can update the dependencies as well.
- remove any lingering `00LOCK` folders due to failed prior installation