### PR TITLE
missing required INBO packages yields a warning instead of an error.

### DIFF
--- a/content/installation/administrator/admin_install_r/Rprofile.site
+++ b/content/installation/administrator/admin_install_r/Rprofile.site
@@ -34,9 +34,10 @@ if ("checklist" %in% rownames(utils::installed.packages())) {
 }
 
 if (
+  interactive() &&
   !all(getOption("inbo_required") %in% rownames(utils::installed.packages()))
 ) {
-  stop(
+  warning(
     c(
       "\n",
       rep("^", getOption("width")),


### PR DESCRIPTION
It is only displayed in interactive sessions.