### PR TITLE
git_authentication: replace andOTP by Aegis

### DIFF
--- a/content/tutorials/git_authentication/index.Rmd
+++ b/content/tutorials/git_authentication/index.Rmd
@@ -43,7 +43,7 @@ If you want to get some intuition about what you are doing, you will need to rea
 
 First, enable two-factor authentication (2FA) for your GitHub account: follow [these steps](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication#configuring-two-factor-authentication-using-a-totp-mobile-app).
 You need a time-based one-time password app for 2FA to work.
-We recommend a mobile app which you can download on your smartphone such as [`andOTP`](https://play.google.com/store/apps/details?id=org.shadowice.flocke.andotp&hl=en&gl=US) (open source, Android) or `Google Authenticator` (closed source, [Android](https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2&hl=en&gl=US) or [iOS](https://apps.apple.com/us/app/google-authenticator/id388497605)).
+We recommend a mobile app which you can download on your smartphone such as [`Aegis`](https://play.google.com/store/apps/details?id=com.beemdevelopment.aegis) (open source, Android) or `Google Authenticator` (closed source, [Android](https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2&hl=en&gl=US) or [iOS](https://apps.apple.com/us/app/google-authenticator/id388497605)).
 
 Next, in R, install the `usethis` package (this will also install packages `gert` and `gitcreds` which we use below) and the `checklist` package:
 
@@ -136,9 +136,9 @@ The first recommendation essentially is an extra layer of security compared to a
 It is unrelated to git operations.
 To enable two-factor authentication for your GitHub account, follow [these steps](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication#configuring-two-factor-authentication-using-a-totp-mobile-app).
 You need a time-based one-time password app for 2FA to work.
-We recommend a mobile app which you can download on your smartphone such as [`andOTP`](https://play.google.com/store/apps/details?id=org.shadowice.flocke.andotp&hl=en&gl=US) (open source, Android) or `Google Authenticator` (closed source, [Android](https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2&hl=en&gl=US) or [iOS](https://apps.apple.com/us/app/google-authenticator/id388497605)).
+We recommend a mobile app which you can download on your smartphone such as [`Aegis`](https://play.google.com/store/apps/details?id=com.beemdevelopment.aegis) (open source, Android) or `Google Authenticator` (closed source, [Android](https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2&hl=en&gl=US) or [iOS](https://apps.apple.com/us/app/google-authenticator/id388497605)).
 The closed tools don't require users 'to read on' and make everything simple, while open tools will require some minimal responsibility e.g. to take care of personal backups.
-Some open source desktop applications are available as well and are listed in https://github.com/andOTP/andOTP/wiki/Open-Source-2FA-Apps.
+Some open source desktop applications are available as well and are listed in https://github.com/andOTP/andOTP/wiki/Open-Source-2FA-Apps and https://en.wikipedia.org/wiki/Comparison_of_OTP_applications.
 Mostly these open source tools are geared towards offline storage and give users maximum control over their credentials.
 2FA is not that intrusive.
 It only kicks in when you login from a new device or when your last login on a device was a long time ago.

--- a/content/tutorials/git_authentication/index.md
+++ b/content/tutorials/git_authentication/index.md
@@ -57,7 +57,7 @@ follow [these
 steps](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication#configuring-two-factor-authentication-using-a-totp-mobile-app).
 You need a time-based one-time password app for 2FA to work. We
 recommend a mobile app which you can download on your smartphone such as
-[`andOTP`](https://play.google.com/store/apps/details?id=org.shadowice.flocke.andotp&hl=en&gl=US)
+[`Aegis`](https://play.google.com/store/apps/details?id=com.beemdevelopment.aegis)
 (open source, Android) or `Google Authenticator` (closed source,
 [Android](https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2&hl=en&gl=US)
 or
@@ -181,7 +181,7 @@ follow [these
 steps](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication#configuring-two-factor-authentication-using-a-totp-mobile-app).
 You need a time-based one-time password app for 2FA to work. We
 recommend a mobile app which you can download on your smartphone such as
-[`andOTP`](https://play.google.com/store/apps/details?id=org.shadowice.flocke.andotp&hl=en&gl=US)
+[`Aegis`](https://play.google.com/store/apps/details?id=com.beemdevelopment.aegis)
 (open source, Android) or `Google Authenticator` (closed source,
 [Android](https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2&hl=en&gl=US)
 or
@@ -190,7 +190,8 @@ The closed tools don’t require users ‘to read on’ and make everything
 simple, while open tools will require some minimal responsibility
 e.g. to take care of personal backups. Some open source desktop
 applications are available as well and are listed in
-<https://github.com/andOTP/andOTP/wiki/Open-Source-2FA-Apps>. Mostly
+<https://github.com/andOTP/andOTP/wiki/Open-Source-2FA-Apps> and
+<https://en.wikipedia.org/wiki/Comparison_of_OTP_applications>. Mostly
 these open source tools are geared towards offline storage and give
 users maximum control over their credentials. 2FA is not that intrusive.
 It only kicks in when you login from a new device or when your last


### PR DESCRIPTION

<!--- indicate the Title for this pull request (PR) above -->

<!--
Thank you for contributing to the INBO tutorials repository.
-->

## Description

andOTP is no longer maintained since 2022:
https://xdaforums.com/t/unmaintained-app-4-4-open-source-andotp-open-source-two-factor-authentication-for-android.3636993/page-6#post-87021655

In the same forum thread, Aegis is recommended as open-source alternative. It is indeed actively maintained and I can testify that it works very well. Also, it can import the keys from andOTP.

See https://github.com/beemdevelopment/Aegis

## Previewing the pull request

Thanks to GitHub Actions, an artifact (=zip file) of the rendered website is automatically created for each pull request.
This provides a way to preview how these updates will look on the website, useful to contributors and reviewers.

### Instructions to preview the updated website

1) On the PR page, you can find a "details" link under "checks - On PR, build the site and ...". Go there, click on the top link in the left sidebar ("Summary"), and download the generated artifact at the bottom of the page.
2) Decompress it and make sure the target directory is called 'tutorials' (you may need to rename it)
3) From the parent directory (just above the `tutorials` folder you created/renamed), run `python -m http.server 8887`, _or_ launch the Google Chrome [Web Server app](https://chrome.google.com/webstore/detail/web-server-for-chrome/ofhbbkphhbklhfoeikjpcbhemlocgigb) and point it at the parent directory.
4) Point your browser to http://localhost:8887/tutorials.
5) Review the updated website. As a contributor, you can push extra commits to update the PR. As a reviewer, you can accept/refuse/comment the PR.

**Note: for step 3, you can use any other simple HTTP server to serve the current directory if you don't have a Python 3 environment or Google Chrome available.**
