### PR TITLE
Rprofile.site: add option qgisprocess.detect_newer_qgis = TRUE

### DIFF
--- a/content/installation/administrator/admin_install_r/Rprofile.site
+++ b/content/installation/administrator/admin_install_r/Rprofile.site
@@ -15,7 +15,8 @@ options(
   pkgType = "binary",
   install.packages.check.source = "no",
   install.packages.compile.from.source = "never",
-  inbo_required = c("checklist", "fortunes", "remotes", "INBOmd", "INBOtheme")
+  inbo_required = c("checklist", "fortunes", "remotes", "INBOmd", "INBOtheme"),
+  qgisprocess.detect_newer_qgis = TRUE
 )
 # display fortune when starting new interactive R session
 if (interactive() && "fortunes" %in% rownames(utils::installed.packages())) {


### PR DESCRIPTION
For upcoming versions of {qgisprocess}, upon loading the package it will detect the availability of a more recent standalone QGIS installation in Windows & macOS than the version currently set in {qgisprocess}, if the latter is also still installed. {qgisprocess} will then offer to use the newer version instead, on condition that option `qgisprocess.detect_newer_qgis` is set as `TRUE`.