### PR TITLE
Adapt tech settings after change deployment domain

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 theme = "minimo"
-baseURL = "https://inbo.github.io/tutorials/"
+baseURL = "http://tutorials.inbo.be/"
 languageCode = "en-us"
 title = "INBO Tutorials"
 


### PR DESCRIPTION
@TheJenne18 has updated the URL of both coding club and tutorials websites. 🥳 
The old URLs are now redirecting to the new INBO branded URLs (`xyz.inbo.be`). Example: http://tutorials.inbo.be/

The problem is that only the homepage is available, and it is rendered as basic HTML (no style).

