### PR TITLE
Remove `baseurl`

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,4 @@
 theme = "minimo"
-baseURL = "http://tutorials.inbo.be/"
 languageCode = "en-us"
 title = "INBO Tutorials"
 


### PR DESCRIPTION
The website is back online. @peterdesmet removed the baseurl in coding club config file (see https://github.com/inbo/coding-club/commit/4305eafaaae6e7a02b39413d5ae1e01f9408d7fe) as it was empty there. We would like to do the same here.
