### PR TITLE
Switch to using artifacts v4

### DIFF
--- a/.github/workflows/generate-artifact-pr.yml
+++ b/.github/workflows/generate-artifact-pr.yml
@@ -38,7 +38,7 @@ jobs:
         run: node themes/minimo/scripts/generate-search-index-lunr.js
 
       - name: Archive built site to an artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pr-${{ env.PR_NUMBER }}-inbo-tutorials-website
           path: public


### PR DESCRIPTION
Closes #349 

In this PR I made a single letter change to switch over to a new version of github artifacts, because the version currently in use will be deprecated on december 5th. See issue for more info. 