### PR TITLE
fix url

### DIFF
--- a/content/tutorials/r_inbomd/index.md
+++ b/content/tutorials/r_inbomd/index.md
@@ -9,6 +9,6 @@ tags: ["r", "bookdown", "rmarkdown", "INBOmd", "gitbook", "e-book"]
 
 During this workshop you learn how to turn a regular Rmarkdown file into a bookdown document using the INBO corporate identity. A lot of tips and trics use plain bookdown. So you can use them with other bookdown output formats.
 
-The [slides](https://inbomd-examples.netlify.com/inbomd_workshop/inbomd_workshop.pdf) are available on the [INBOmd examples](https://inbomd-examples.netlify.com) website.
+The [slides](https://inbo.github.io/inbomd_examples/inbomd_workshop/inbomd_workshop.pdf) are available on the [INBOmd examples](https://inbo.github.io/inbomd_examples/) website.
 
 The [source code](https://github.com/inbo/inbomd_examples/tree/master/source/inbomd_workshop) is avalaible in the INBOmd example [GitHub repository](https://github.com/inbo/inbomd_examples).


### PR DESCRIPTION
## Description

Fixed moved URLs in INBOmd tutorials

## Task list

- [X] My tutorial or article is placed in a subfolder of `tutorials/content`
- [X] The filename of my tutorial or article is `index.md`. In case of an Rmarkdown tutorial I have knitted my `index.Rmd` to `index.md` (both files are pushed to the repo). 
- [X] I have included `tags` in the YAML header (see the tags listed in the [tutorials website side bar](https://inbo.github.io/tutorials/) for tags that have been used before)
- [X] I have added `categories` to the YAML header and my category tags are from the [list of category tags](https://github.com/inbo/tutorials/blob/master/static/list_of_categories)
