### PR TITLE
spatial/variograms errata: Wrapping, Gauss instead of Matérn, formatting

### DIFF
--- a/content/tutorials/spatial_variograms/index.md
+++ b/content/tutorials/spatial_variograms/index.md
@@ -200,7 +200,7 @@ Usually, we only require unique cross-combinations of elements in arbitrary orde
 ``` r
 # compute the difference of all elements of one vector to each other
 self_difference <- function(vec) outer(X = vec, Y = vec, FUN = function(X, Y) Y - X )
-wrap_difference <- function(vec) outer(X = vec, Y = vec, FUN = function(X, Y) ((Y - X + (extent/2)) %% (extent)) - (extent/2))
+wrap_difference <- function(vec) outer(X = vec, Y = vec, FUN = function(X, Y) ((Y - X + (extent)) %% (2*extent)) - (extent))
 
 # Calculate the Euclidean distance of the x and y columns in a data frame.
 Euclid <- function(data) sqrt(self_difference(data$x)^2 + self_difference(data$y)^2 )

--- a/content/tutorials/spatial_variograms/index.md
+++ b/content/tutorials/spatial_variograms/index.md
@@ -200,7 +200,7 @@ Usually, we only require unique cross-combinations of elements in arbitrary orde
 ``` r
 # compute the difference of all elements of one vector to each other
 self_difference <- function(vec) outer(X = vec, Y = vec, FUN = function(X, Y) Y - X )
-wrap_difference <- function(vec) outer(X = vec, Y = vec, FUN = function(X, Y) (Y - X) %% (2*extent))
+wrap_difference <- function(vec) outer(X = vec, Y = vec, FUN = function(X, Y) ((Y - X + (extent/2)) %% (extent)) - (extent/2))
 
 # Calculate the Euclidean distance of the x and y columns in a data frame.
 Euclid <- function(data) sqrt(self_difference(data$x)^2 + self_difference(data$y)^2 )
@@ -744,7 +744,10 @@ alt="Figure 8: Although it is inverted, scaled, y-shifted, and centered on zero
 
 I still have a hard time to associate anything maths-related to the words `nugget` and `sill`: they could equally well be some ancient greek letters spelled out in a non-greek way, such as `σίγμα`.
 Historically, they stem from what I think were the earliest applications of variogram-like analysis, as my colleague Hans Van Calster confirmed me when reviewing this tutorial:
-\> nugget comes from "gold" nugget in mining. In sampling gold, the chances of finding a nugget of gold from adjacent locations may differ a lot - hence they have a large "nugget" effect (large differences at very small distances).
+
+> nugget comes from "gold" nugget in mining. In sampling gold, the chances of finding a nugget of gold from adjacent locations may differ a lot - hence they have a large "nugget" effect (large differences at very small distances).
+
+
 We have to accept that they are frequently encountered in the variogram literature.
 
 -   The `nugget` is the value our function takes at the zero intercept, i.e. baseline variance, i.e. the lowest difference we can get (often defined by measurement uncertainty).
@@ -795,9 +798,9 @@ plot_residuals_histogram(x, y, predictor_function,
 <img
 src="spatial_variograms.markdown_strict_files/figure-markdown_strict/fig-gauss-residuals-1.png"
 id="fig-gauss-residuals"
-alt="Figure 9: Residual distribution of the Matérn model for semivariance. Reasonably Gaussian as well, with some imagination." />
+alt="Figure 9: Residual distribution of the Gaussian model for semivariance." />
 
-<figcaption>Residual distribution of the Matérn model for semivariance. Reasonably Gaussian as well, with some imagination.</figcaption><br>
+<figcaption>Residual distribution of the Gaussian model for semivariance.</figcaption><br>
 
 The regression results for scale, range, and nugget are 0.12, 16.76, 0.35, respectively.
 

--- a/content/tutorials/spatial_variograms/spatial_variograms.qmd
+++ b/content/tutorials/spatial_variograms/spatial_variograms.qmd
@@ -13,7 +13,7 @@ format:
     variant: -tex_math_dollars+tex_math_single_backslash
     embed-resources: true
   hugo-md:
-    output-file: "index.md"
+    output-file: "index_new.md"
     toc: false
     preserve_yaml: false
     maths: true
@@ -238,7 +238,7 @@ Usually, we only require unique cross-combinations of elements in arbitrary orde
 ```{r cross-distance}
 # compute the difference of all elements of one vector to each other
 self_difference <- function(vec) outer(X = vec, Y = vec, FUN = function(X, Y) Y - X )
-wrap_difference <- function(vec) outer(X = vec, Y = vec, FUN = function(X, Y) (Y - X) %% (2*extent))
+wrap_difference <- function(vec) outer(X = vec, Y = vec, FUN = function(X, Y) ((Y - X + (extent)) %% (2*extent)) - (extent))
 
 # Calculate the Euclidean distance of the x and y columns in a data frame.
 Euclid <- function(data) sqrt(self_difference(data$x)^2 + self_difference(data$y)^2 )
@@ -806,8 +806,11 @@ abline(v = 0)
 
 I still have a hard time to associate anything maths-related to the words `nugget` and `sill`: they could equally well be some ancient greek letters spelled out in a non-greek way, such as `σίγμα`. 
 Historically, they stem from what I think were the earliest applications of variogram-like analysis, as my colleague Hans Van Calster confirmed me when reviewing this tutorial: 
+
 > nugget comes from "gold" nugget in mining. In sampling gold, the chances of finding a nugget of gold from adjacent locations may differ a lot - hence they have a large "nugget" effect (large differences at very small distances).
+
 We have to accept that they are frequently encountered in the variogram literature.
+
 
 - The `nugget` is the value our function takes at the zero intercept, i.e. baseline variance, i.e. the lowest difference we can get (often defined by measurement uncertainty).
 - Conversely, the `sill` is the maximum variance we expect to be reached when comparing measurements at totally unrelated locations. The stereotypical Gaussian variogram will asymptotically approach this value towards infinite distance.
@@ -856,11 +859,11 @@ Inspecting the residual pattern:
 
 ```{r regression-residuals-histogram}
 #| label: fig-gauss-residuals
-#| fig-cap: "Residual distribution of the Matérn model for semivariance. Reasonably Gaussian as well, with some imagination."
+#| fig-cap: "Residual distribution of the Gaussian model for semivariance."
 plot_residuals_histogram(x, y, predictor_function,
   bins = 32, fill = "lightgray", color = "black")
 ```
-`<figcaption>Residual distribution of the Matérn model for semivariance. Reasonably Gaussian as well, with some imagination.</figcaption><br>`{=markdown}
+`<figcaption>Residual distribution of the Gaussian model for semivariance.</figcaption><br>`{=markdown}
 
 
 The regression results for scale, range, and nugget are `{r} paste(round(optimizer_results$par, 2), collapse = ", ")`, respectively.
@@ -1555,3 +1558,7 @@ Useful links:
 - <https://www.paulamoraga.com/book-spatial/geostatistical-data-1.html>
 - <https://desktop.arcgis.com/en/arcmap/10.3/guide-books/extensions/geostatistical-analyst/empirical-semivariogram-and-covariance-functions.htm>
 
+
+# Changelog
+
+- *(2026-03-31)* Fix an error in "wrapping", discovered during work on <https://falk.mielke.ws/posts/43.variogram_data_quantization/>. Code adjusted, but rendering not repeated to avoid git binary overwrite.


### PR DESCRIPTION
This PR corrects minor errors in the tutorial on spatial analysis / variograms.

- There was a putative error in the interval wrapping function; I have double checked the new one in a separate article (linked as footnote; but the link is optional -> feel free to remove).
- formatting: space missing before a quote
- reference to a wrong distribution function

This has very minor implications for the actual (randomly generated) data. 
Therefore, I suggest to not re-calculate and re-commit the figure binaries.
(Instead, I have simply corrected the respective code lines.)